### PR TITLE
[feat] SpringBoot -> Discord 웹훅 연결

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/exception/RestClientException.java
+++ b/src/main/java/site/offload/offloadserver/api/exception/RestClientException.java
@@ -1,0 +1,16 @@
+package site.offload.offloadserver.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class RestClientException extends RuntimeException {
+
+    public RestClientException(RestClientUseCase restClientUseCase, String message, HttpStatus httpStatus) {
+        super(formatMessage(restClientUseCase, message, httpStatus));
+    }
+
+    private static String formatMessage(RestClientUseCase restClientUseCase, String message, HttpStatus status) {
+        return "RestClientUseCase: " + restClientUseCase.toString() + "\n" +
+                "Status Code: " + status.toString() + "\n" +
+                "Error message: " + message;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/exception/RestClientUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/exception/RestClientUseCase.java
@@ -1,0 +1,6 @@
+package site.offload.offloadserver.api.exception;
+
+public enum RestClientUseCase {
+    DISCORD_WEBHOOK
+}
+

--- a/src/main/java/site/offload/offloadserver/api/message/ErrorMessage.java
+++ b/src/main/java/site/offload/offloadserver/api/message/ErrorMessage.java
@@ -18,7 +18,7 @@ public enum ErrorMessage {
     /* 404 Not Found */
 
     /* 500 Internal Server Error */
-
+    ERROR_MESSAGE("example",HttpStatus.INTERNAL_SERVER_ERROR);
     private final String message;
     private final HttpStatus httpStatus;
 }

--- a/src/main/java/site/offload/offloadserver/external/discord/DiscordService.java
+++ b/src/main/java/site/offload/offloadserver/external/discord/DiscordService.java
@@ -1,0 +1,41 @@
+package site.offload.offloadserver.external.discord;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import site.offload.offloadserver.api.exception.RestClientException;
+import site.offload.offloadserver.api.exception.RestClientUseCase;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordService {
+
+    @Value("${discord.webhook-url}")
+    private String WEBHOOK_URL;
+
+    public void sendMessage(final DiscordWebhookRequest discordWebhookRequest) {
+        final RestClient restClient = RestClient.create();
+        try {
+            restClient.post()
+                    .uri(WEBHOOK_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(discordWebhookRequest)
+                    .retrieve()
+                    .onStatus(
+                            status -> status.is4xxClientError() || status.is5xxServerError(),
+                            (request, response) -> {
+                                throw new RestClientException(RestClientUseCase.DISCORD_WEBHOOK,
+                                        response.getBody().toString(),(HttpStatus) response.getStatusCode());
+                            }
+                    );
+        } catch (RestClientException exception) {
+            log.error(exception.getMessage(), exception);
+        }
+    }
+}
+

--- a/src/main/java/site/offload/offloadserver/external/discord/DiscordWebhookRequest.java
+++ b/src/main/java/site/offload/offloadserver/external/discord/DiscordWebhookRequest.java
@@ -1,0 +1,14 @@
+package site.offload.offloadserver.external.discord;
+
+import java.util.List;
+
+public record DiscordWebhookRequest(String content, List<Embed> embeds) {
+
+    public DiscordWebhookRequest {
+        // content 최대 2000자
+        content = content.length() > 2000 ? content.substring(0, 2000) : content;
+
+        // embeds 최대 10개
+        embeds = embeds.size() > 10 ? embeds.subList(0, 10) : embeds;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/external/discord/Embed.java
+++ b/src/main/java/site/offload/offloadserver/external/discord/Embed.java
@@ -1,0 +1,12 @@
+package site.offload.offloadserver.external.discord;
+
+public record Embed(String title, String description) {
+
+    public Embed {
+        //title 최대 256자
+        title = title.length() > 256 ? title.substring(0, 256) : title;
+
+        //description 최대 2048자
+        description = description.length() > 2048 ? description.substring(0, 2048) : description;
+    }
+}


### PR DESCRIPTION
## 변경사항
- application.local-yaml 파일 수정
```yaml
spring:
  application:
    name: offloadserver
  config:
    activate:
      on-profile: local
discord:
  webhook-url: {디스코드 채널 웹훅 url}
```
- external/discord 디렉토리 아래 웹훅 알림에 필요한 DiscordService, DiscordWebhookRequest, Embed 클래스 작성 
## 고려사항
- API 통신 방법으로 처음에는 OpenFeign을 채택했습니다. 하지만 더 찾아보니 스프링 공식문서에서 OpenFeign에 대해 더 이상 기능 구현을 하지 않는 다는 것과 다른 방식으로 migrating하는 것을 권장하는 내용을 찾았습니다.([관련 문서](https://spring.io/projects/spring-cloud-openfeign)). 그래서 RestClient와 WebClient 사이에서 고민했고, RestClient가 저희 서비스 규모에 적당하고 구현이 간결하며 Spring Framework 자체 기술이라는 점에서 RestClient를 선택하고 구현했습니다.
- 디스코드 알림으로 운영 서버의 에러만 전송할지, 로컬 서버에서 각자 테스트 할 때 발생하는 에러도 전송할지 고민했습니다. 두 경우 모두 알림으로 발송하는 것이 서로 의논하며 디버깅하는 것에 도움을 줄 것 같아 두 경우 모두 알림 발송하는 쪽으로 구현했습니다.
  - 운영 서버와 로컬 서버의 구분: application-local.yaml과 application-dev.yaml에서 구분되는 spring.config.activate.on-profile 의 값이 local인지, dev인지 자바 파일에서 PlaceHolder로 구분합니다. 이 부분은 코드에서 확인 부탁드립니다.   
## Comment
- 로컬 환경 인텔리제이에서 Run할 경우, Run->Edit Configurations-> Active Profiles 부분을 local로 설정하지 않으면 yaml파일에서 정의한 값이 PlaceHolder로 인식되지 않아 에러가 발생합니다! 
- 디스코드 API 스펙 상 Content와 Embed를 DiscordWebhookRequest DTO에 포함시켰습니다( [관련문서1](https://discord.com/developers/docs/resources/webhook)/[관련문서2](https://discord.com/safety/using-webhooks-and-embeds)). Discord 상에서 Embed는, 관련문서2에 따르면 제 생각에는 이미지/링크/문서 등을 다양하게 포함시킬 수 있는 박스라고 할 수 있을 것 같습니다. Content로 운영 서버 에러/로컬 서버 에러를 나타내고, Embed 안에 있는 title, descripton을 DTO에 포함시켜 title에는 "에러 정보"라는 제목을, description에는 실제 에러 정보를 2048자 제한으로 포함시켰습니다.
- 아래 Test에서 진행한 TestController, TestService는 commit하지 않았습니다 
## Test
- GlobalExceptionHandler.java
```java
@RestControllerAdvice
@RequiredArgsConstructor
public class GlobalExceptionHandler {

    private final DiscordService discordService;

    @ExceptionHandler(Exception.class)
    protected void discordWebhookTest(Exception exception) {
        discordService.sendWebhook(exception, HttpStatus.INTERNAL_SERVER_ERROR);
    }
}
```
- TestController
```java
@RestController
@RequiredArgsConstructor
public class TestController {

    private final TestService testService;

    @GetMapping("/test")
    public void test() {
        testService.test();
    }
}
```

- TestService
```java
@Service
public class TestService {

    public void test()  {
        throw new IllegalStateException();
    }
}
```

- Postman으로 에러 발생 요청 보낼 시
<img width="424" alt="image" src="https://github.com/Team-Offroad/Offroad-server/assets/121341289/2abbe138-a324-42f3-9799-7333fedc4a74">
<img width="397" alt="image" src="https://github.com/Team-Offroad/Offroad-server/assets/121341289/1ca316cd-1900-4099-8221-a8b9989f1c20">

## 질문사항
- 운영인지 로컬인지 구분하는 방식에 대해서 적절한지 의견부탁드립니다. 보완/수정했으면 좋겠다는 부분도 말씀해주세요! 
