### PR TITLE
[feat] API 응답 포맷 세팅

### DIFF
--- a/src/main/java/site/offload/offloadserver/common/api/message/ErrorMessage.java
+++ b/src/main/java/site/offload/offloadserver/common/api/message/ErrorMessage.java
@@ -1,0 +1,12 @@
+package site.offload.offloadserver.common.api.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMessage {
+
+}

--- a/src/main/java/site/offload/offloadserver/common/api/message/SuccessMessage.java
+++ b/src/main/java/site/offload/offloadserver/common/api/message/SuccessMessage.java
@@ -1,0 +1,11 @@
+package site.offload.offloadserver.common.api.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessMessage {
+
+
+}

--- a/src/main/java/site/offload/offloadserver/common/api/response/APIErrorResponse.java
+++ b/src/main/java/site/offload/offloadserver/common/api/response/APIErrorResponse.java
@@ -1,0 +1,13 @@
+package site.offload.offloadserver.common.api.response;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public record APIErrorResponse(
+        String message
+) {
+    public static ResponseEntity<APIErrorResponse> of(int statusCode, String message) {
+        return ResponseEntity.status(statusCode).body(new APIErrorResponse(message));
+    }
+}

--- a/src/main/java/site/offload/offloadserver/common/api/response/APISuccessResponse.java
+++ b/src/main/java/site/offload/offloadserver/common/api/response/APISuccessResponse.java
@@ -1,0 +1,12 @@
+package site.offload.offloadserver.common.api.response;
+
+import org.springframework.http.ResponseEntity;
+
+public record APISuccessResponse<T>(
+        String message,
+        T data
+) {
+    public static <T> ResponseEntity<APISuccessResponse<T>> of(int statusCode, String message, T data) {
+        return ResponseEntity.status(statusCode).body(new APISuccessResponse<T>(message, data));
+    }
+}


### PR DESCRIPTION
## 변경사항

### 응답 성공 API Response 포맷
https://github.com/Team-Offroad/Offroad-server/blob/75cc6468e120590e34f7f09333428f818f356228/src/main/java/site/offload/offloadserver/common/api/response/APISuccessResponse.java#L5-L12

* 제네릭 타입 T를 이용했습니다.

### 응답 실패 API Response 포맷
https://github.com/Team-Offroad/Offroad-server/blob/75cc6468e120590e34f7f09333428f818f356228/src/main/java/site/offload/offloadserver/common/api/response/APIErrorResponse.java#L7-L13

### 성공 및 실패 메시지

https://github.com/Team-Offroad/Offroad-server/blob/75cc6468e120590e34f7f09333428f818f356228/src/main/java/site/offload/offloadserver/common/api/message/ErrorMessage.java#L9-L12

* RequiredArgsConstructor를 사용했습니다.

## 고려사항

* common 패키지 아래에 api패키지를 만들었습니다. 그리고 그 아래 response, message 패키지를 따로 만들어 생성했습니다. 

* 세미나에서는 ok(), created(), badRequest() 등 특정한 상황을 가정해서 사용했어서 일반적으로 포맷을 어떻게 구상할지 고민이었습니다. 그러다 status를 이용하여 이 부분에 상태코드를 삽입하고, 반환값에는 코드를 제외한 메시지와 데이터를 담아 보내는 것이 좋다고 생각했습니다. 

* 세미나에서와 다르게 AllArgsConstructor 대신 RequiredArgsConstructor를 사용했습니다. 

## 질문사항

* 잘못된 부분, 다른 의견이 있으시다면 모두 말씀해주시면 감사하겠습니다!