### PR TITLE
[feat] Entity Setting

### DIFF
--- a/src/main/java/site/offload/offloadserver/common/config/JpaAuditingConfig.java
+++ b/src/main/java/site/offload/offloadserver/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package site.offload.offloadserver.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/Announcement.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Announcement.java
@@ -14,7 +14,7 @@ public class Announcement extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     private String writer;
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/src/main/java/site/offload/offloadserver/db/entity/Announcement.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Announcement.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 //공지사항
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Announcement extends BaseTime {
+public class Announcement extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/offload/offloadserver/db/entity/Announcement.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Announcement.java
@@ -22,11 +22,4 @@ public class Announcement extends BaseTimeEntity {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
-
-    @Builder
-    private Announcement(String writer, String title, String content) {
-        this.writer = writer;
-        this.title = title;
-        this.content = content;
-    }
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/Announcement.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Announcement.java
@@ -1,0 +1,32 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+//공지사항
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Announcement extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String writer;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Builder
+    private Announcement(String writer, String title, String content) {
+        this.writer = writer;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/BaseTime.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/BaseTime.java
@@ -1,5 +1,6 @@
 package site.offload.offloadserver.db.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
@@ -15,9 +16,11 @@ import java.time.LocalDateTime;
 public abstract class BaseTime {
 
     @CreatedDate
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 }
 

--- a/src/main/java/site/offload/offloadserver/db/entity/BaseTime.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/BaseTime.java
@@ -1,0 +1,24 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTime {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}
+
+

--- a/src/main/java/site/offload/offloadserver/db/entity/BaseTimeEntity.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/BaseTimeEntity.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseTime {
+public abstract class BaseTimeEntity {
 
     @CreatedDate
     @Column(nullable = false)

--- a/src/main/java/site/offload/offloadserver/db/entity/Character.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Character.java
@@ -1,0 +1,32 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+//캐릭터
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Character extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String name;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false, unique = true, columnDefinition = "TEXT")
+    private String characterBaseImageUrl;
+
+    @Builder
+    private Character(String name, String description, String characterBaseImageUrl) {
+        this.name = name;
+        this.description = description;
+        this.characterBaseImageUrl = characterBaseImageUrl;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/Character.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Character.java
@@ -23,6 +23,9 @@ public class Character extends BaseTime {
     @Column(nullable = false, unique = true, columnDefinition = "TEXT")
     private String characterBaseImageUrl;
 
+    @Column(nullable = false, unique = true, columnDefinition = "TEXT")
+    private String CharacterCode;
+
     @Builder
     private Character(String name, String description, String characterBaseImageUrl) {
         this.name = name;

--- a/src/main/java/site/offload/offloadserver/db/entity/Character.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Character.java
@@ -14,7 +14,7 @@ public class Character extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     private String name;
 
     @Column(nullable = false, columnDefinition = "TEXT")
@@ -23,7 +23,7 @@ public class Character extends BaseTime {
     @Column(nullable = false, unique = true, columnDefinition = "TEXT")
     private String characterBaseImageUrl;
 
-    @Column(nullable = false, unique = true, columnDefinition = "TEXT")
+    @Column(nullable = false, unique = true)
     private String CharacterCode;
 
     @Builder

--- a/src/main/java/site/offload/offloadserver/db/entity/Character.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Character.java
@@ -25,11 +25,4 @@ public class Character extends BaseTimeEntity {
 
     @Column(nullable = false, unique = true)
     private String CharacterCode;
-
-    @Builder
-    private Character(String name, String description, String characterBaseImageUrl) {
-        this.name = name;
-        this.description = description;
-        this.characterBaseImageUrl = characterBaseImageUrl;
-    }
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/Character.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Character.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 //캐릭터
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Character extends BaseTime {
+public class Character extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/offload/offloadserver/db/entity/CharacterMotion.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/CharacterMotion.java
@@ -19,7 +19,7 @@ public class CharacterMotion extends BaseTime{
     private Character character;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     private PlaceCategory placeCategory;
 
     @Column(nullable = false, unique = true, columnDefinition = "TEXT")

--- a/src/main/java/site/offload/offloadserver/db/entity/CharacterMotion.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/CharacterMotion.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 //각 캐릭터의 모션
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CharacterMotion extends BaseTime{
+public class CharacterMotion extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/offload/offloadserver/db/entity/CharacterMotion.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/CharacterMotion.java
@@ -24,11 +24,4 @@ public class CharacterMotion extends BaseTimeEntity {
 
     @Column(nullable = false, unique = true, columnDefinition = "TEXT")
     private String motionImageUrl;
-
-    @Builder
-    private CharacterMotion(Character character, PlaceCategory placeCategory, String motionImageUrl) {
-        this.character = character;
-        this.placeCategory = placeCategory;
-        this.motionImageUrl = motionImageUrl;
-    }
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/CharacterMotion.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/CharacterMotion.java
@@ -1,0 +1,34 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+//각 캐릭터의 모션
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CharacterMotion extends BaseTime{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "character_id", nullable = false)
+    private Character character;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private PlaceCategory placeCategory;
+
+    @Column(nullable = false, unique = true, columnDefinition = "TEXT")
+    private String motionImageUrl;
+
+    @Builder
+    private CharacterMotion(Character character, PlaceCategory placeCategory, String motionImageUrl) {
+        this.character = character;
+        this.placeCategory = placeCategory;
+        this.motionImageUrl = motionImageUrl;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/Coupon.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Coupon.java
@@ -14,13 +14,13 @@ public class Coupon extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     private String name;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
 
-    @Column(nullable = false, unique = true, columnDefinition = "TEXT")
+    @Column(nullable = false, unique = true)
     private String couponCode;
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/src/main/java/site/offload/offloadserver/db/entity/Coupon.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Coupon.java
@@ -1,0 +1,36 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+//보상으로 얻을 수 있는 쿠폰
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String name;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false, unique = true, columnDefinition = "TEXT")
+    private String couponCode;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String couponImageUrl;
+
+    @Builder
+    private Coupon(String name, String couponCode, String description, String couponImageUrl) {
+        this.name = name;
+        this.couponCode = couponCode;
+        this.description = description;
+        this.couponImageUrl = couponImageUrl;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/Coupon.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Coupon.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 //보상으로 얻을 수 있는 쿠폰
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Coupon extends BaseTime {
+public class Coupon extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/offload/offloadserver/db/entity/Coupon.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Coupon.java
@@ -25,12 +25,4 @@ public class Coupon extends BaseTimeEntity {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String couponImageUrl;
-
-    @Builder
-    private Coupon(String name, String couponCode, String description, String couponImageUrl) {
-        this.name = name;
-        this.couponCode = couponCode;
-        this.description = description;
-        this.couponImageUrl = couponImageUrl;
-    }
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/Emblem.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Emblem.java
@@ -1,0 +1,11 @@
+package site.offload.offloadserver.db.entity;
+
+import lombok.RequiredArgsConstructor;
+
+//칭호
+@RequiredArgsConstructor
+public enum Emblem  {
+    //예시 칭호
+    EMBLEM_CODE("EMBLEM001");
+    private final String emblemCodeName;
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/GainedCharacter.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/GainedCharacter.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 //사용자가 얻은 캐릭터
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GainedCharacter extends BaseTime {
+public class GainedCharacter extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/offload/offloadserver/db/entity/GainedCharacter.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/GainedCharacter.java
@@ -1,0 +1,24 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+//사용자가 얻은 캐릭터
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GainedCharacter extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "character_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Character character;
+
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/GainedCoupon.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/GainedCoupon.java
@@ -23,7 +23,7 @@ public class GainedCoupon extends BaseTimeEntity {
     @JoinColumn(name = "coupon_id", nullable = false)
     private Coupon coupon;
 
-    private boolean isUsed;
+    private boolean isUsed = false;
 
     @Builder
     private GainedCoupon(Member member, Coupon coupon) {

--- a/src/main/java/site/offload/offloadserver/db/entity/GainedCoupon.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/GainedCoupon.java
@@ -1,0 +1,34 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+//사용자가 얻은 쿠폰
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table
+public class GainedCoupon extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    private boolean isUsed;
+
+    @Builder
+    private GainedCoupon(Member member, Coupon coupon) {
+        this.member = member;
+        this.coupon = coupon;
+        this.isUsed = false;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/GainedCoupon.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/GainedCoupon.java
@@ -24,11 +24,4 @@ public class GainedCoupon extends BaseTimeEntity {
     private Coupon coupon;
 
     private boolean isUsed = false;
-
-    @Builder
-    private GainedCoupon(Member member, Coupon coupon) {
-        this.member = member;
-        this.coupon = coupon;
-        this.isUsed = false;
-    }
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/GainedCoupon.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/GainedCoupon.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table
-public class GainedCoupon extends BaseTime {
+public class GainedCoupon extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/offload/offloadserver/db/entity/GainedEmblem.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/GainedEmblem.java
@@ -18,7 +18,7 @@ public class GainedEmblem {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Emblem emblemName;
 

--- a/src/main/java/site/offload/offloadserver/db/entity/GainedEmblem.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/GainedEmblem.java
@@ -21,10 +21,4 @@ public class GainedEmblem {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Emblem emblemName;
-
-    @Builder
-    private GainedEmblem(Member member, Emblem emblemName) {
-        this.member = member;
-        this.emblemName = emblemName;
-    }
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/GainedEmblem.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/GainedEmblem.java
@@ -1,0 +1,30 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+//사용자가 얻은 칭호
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GainedEmblem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    @Enumerated(EnumType.STRING)
+    private Emblem emblemName;
+
+    @Builder
+    private GainedEmblem(Member member, Emblem emblemName) {
+        this.member = member;
+        this.emblemName = emblemName;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/Member.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Member.java
@@ -1,0 +1,51 @@
+package site.offload.offloadserver.db.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+//로그인 유저
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 소셜 로그인 기반 정보 : name(필수), email(필수), gender(선택), age(선택)
+     */
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String name;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String email;
+
+    @Column(columnDefinition = "TEXT")
+    @Enumerated(EnumType.STRING)
+    private MemberGender gender;
+
+    @Column(columnDefinition = "integer CHECK (age >= 0)")
+    private int age;
+
+    @Column(unique = true, columnDefinition = "TEXT")
+    private String nickName;
+
+    @Column(columnDefinition = "TEXT")
+    private String currentCharacterName;
+
+    @Column(columnDefinition = "TEXT")
+    private String currentEmblemName;
+
+    @Builder
+    private Member(String nickName, String name, String email, MemberGender gender, int age) {
+        this.nickName = nickName;
+        this.name = name;
+        this.email = email;
+        this.gender = gender;
+        this.age = age;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/Member.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Member.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 //로그인 유저
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member extends BaseTime {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/offload/offloadserver/db/entity/Member.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Member.java
@@ -18,26 +18,25 @@ public class Member extends BaseTime {
     /**
      * 소셜 로그인 기반 정보 : name(필수), email(필수)
      */
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     private String email;
 
-    @Column(columnDefinition = "TEXT")
     @Enumerated(EnumType.STRING)
     private MemberGender gender;
 
     @Column(columnDefinition = "integer CHECK (age >= 0)")
     private int age;
 
-    @Column(unique = true, columnDefinition = "TEXT")
+    @Column(unique = true)
     private String nickName;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(nullable = false)
     private String currentCharacterName;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(nullable = false)
     private String currentEmblemName;
 
     @Builder

--- a/src/main/java/site/offload/offloadserver/db/entity/Member.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Member.java
@@ -38,13 +38,4 @@ public class Member extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String currentEmblemName;
-
-    @Builder
-    private Member(String nickName, String name, String email, MemberGender gender, int age) {
-        this.nickName = nickName;
-        this.name = name;
-        this.email = email;
-        this.gender = gender;
-        this.age = age;
-    }
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/Member.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Member.java
@@ -16,7 +16,7 @@ public class Member extends BaseTime {
     private Long id;
 
     /**
-     * 소셜 로그인 기반 정보 : name(필수), email(필수), gender(선택), age(선택)
+     * 소셜 로그인 기반 정보 : name(필수), email(필수)
      */
     @Column(nullable = false, columnDefinition = "TEXT")
     private String name;

--- a/src/main/java/site/offload/offloadserver/db/entity/MemberGender.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/MemberGender.java
@@ -3,5 +3,5 @@ package site.offload.offloadserver.db.entity;
 //유저 성별
 public enum MemberGender {
     MALE,
-    FAMALE
+    FEMALE
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/MemberGender.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/MemberGender.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.entity;
+
+//유저 성별
+public enum MemberGender {
+    MALE,
+    FAMALE
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/Place.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Place.java
@@ -27,10 +27,10 @@ public class Place extends BaseTime {
     @Column(nullable = false, columnDefinition = "TEXT")
     private PlaceCategory placeCategory;
 
-    @Column(nullable = false, columnDefinition = "float CHECK (latitude < -90) OR (latitude > 90)")
+    @Column(nullable = false, columnDefinition = "float CHECK (latitude >= -90 AND latitude <= 90)")
     private float latitude;
 
-    @Column(nullable = false, columnDefinition = "float CHECK (longitude < -180) OR (longitude > 180)")
+    @Column(nullable = false, columnDefinition = "float CHECK (longitude >= -180 AND longitude <= 180)")
     private float longitude;
 
     @Builder

--- a/src/main/java/site/offload/offloadserver/db/entity/Place.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Place.java
@@ -14,17 +14,17 @@ public class Place extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     private String address;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String shortIntroduction;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false)
     private PlaceCategory placeCategory;
 
     @Column(nullable = false, columnDefinition = "float CHECK (latitude >= -90 AND latitude <= 90)")

--- a/src/main/java/site/offload/offloadserver/db/entity/Place.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Place.java
@@ -32,15 +32,4 @@ public class Place extends BaseTimeEntity {
 
     @Column(nullable = false, columnDefinition = "float CHECK (longitude >= -180 AND longitude <= 180)")
     private float longitude;
-
-    @Builder
-    private Place(String name, String address, String shortIntroduction,
-     PlaceCategory placeCategory, float latitude, float longitude) {
-        this.name = name;
-        this.address = address;
-        this.shortIntroduction = shortIntroduction;
-        this.placeCategory = placeCategory;
-        this.latitude = latitude;
-        this.longitude = longitude;
-    }
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/Place.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Place.java
@@ -1,0 +1,46 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+//서비스에 등록된 장소
+@Entity
+@NoArgsConstructor(access =  AccessLevel.PROTECTED)
+public class Place extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String name;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String address;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String shortIntroduction;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private PlaceCategory placeCategory;
+
+    @Column(nullable = false, columnDefinition = "float CHECK (latitude < -90) OR (latitude > 90)")
+    private float latitude;
+
+    @Column(nullable = false, columnDefinition = "float CHECK (longitude < -180) OR (longitude > 180)")
+    private float longitude;
+
+    @Builder
+    private Place(String name, String address, String shortIntroduction,
+     PlaceCategory placeCategory, float latitude, float longitude) {
+        this.name = name;
+        this.address = address;
+        this.shortIntroduction = shortIntroduction;
+        this.placeCategory = placeCategory;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/Place.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Place.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 //서비스에 등록된 장소
 @Entity
 @NoArgsConstructor(access =  AccessLevel.PROTECTED)
-public class Place extends BaseTime {
+public class Place extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/offload/offloadserver/db/entity/PlaceCategory.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/PlaceCategory.java
@@ -1,0 +1,11 @@
+package site.offload.offloadserver.db.entity;
+
+//장소 카테고리
+public enum PlaceCategory {
+    CAFFE,
+    PARK,
+    RESTAURANT,
+    CULTURE,
+    SPORT,
+    NONE
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/Quest.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/Quest.java
@@ -1,0 +1,8 @@
+package site.offload.offloadserver.db.entity;
+
+public enum Quest {
+
+    //예시 퀘스트 코드
+    QUEST_CODE;
+    private String QuestCode;
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/VisitedPlace.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/VisitedPlace.java
@@ -25,10 +25,4 @@ public class VisitedPlace {
     //사용자가 방문한 장소이므로, 기본값을 1로 설정
     @Column(columnDefinition = "integer CHECK (visit_count >= 1)")
     private static int visitCount = 1;
-
-    @Builder
-    private VisitedPlace(Member member, Place place) {
-        this.member = member;
-        this.place = place;
-    }
 }

--- a/src/main/java/site/offload/offloadserver/db/entity/VisitedPlace.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/VisitedPlace.java
@@ -1,0 +1,34 @@
+package site.offload.offloadserver.db.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+//사용자가 방문한 장소
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VisitedPlace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    //사용자가 방문한 장소이므로, 기본값을 1로 설정
+    @Column(columnDefinition = "integer CHECK (visit_count >= 1)")
+    private int visitCount = 1;
+
+    @Builder
+    private VisitedPlace(Member member, Place place) {
+        this.member = member;
+        this.place = place;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/entity/VisitedPlace.java
+++ b/src/main/java/site/offload/offloadserver/db/entity/VisitedPlace.java
@@ -24,7 +24,7 @@ public class VisitedPlace {
 
     //사용자가 방문한 장소이므로, 기본값을 1로 설정
     @Column(columnDefinition = "integer CHECK (visit_count >= 1)")
-    private int visitCount = 1;
+    private static int visitCount = 1;
 
     @Builder
     private VisitedPlace(Member member, Place place) {

--- a/src/main/java/site/offload/offloadserver/db/repository/AnnouncementRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/AnnouncementRepository.java
@@ -3,5 +3,5 @@ package site.offload.offloadserver.db.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.offload.offloadserver.db.entity.Announcement;
 
-public interface AnnouncementRepository extends JpaRepository<Announcement, Integer> {
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
 }

--- a/src/main/java/site/offload/offloadserver/db/repository/AnnouncementRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/AnnouncementRepository.java
@@ -1,7 +1,7 @@
 package site.offload.offloadserver.db.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 import site.offload.offloadserver.db.entity.Announcement;
 
-public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+public interface AnnouncementRepository extends CrudRepository<Announcement, Long> {
 }

--- a/src/main/java/site/offload/offloadserver/db/repository/AnnouncementRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/AnnouncementRepository.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.offload.offloadserver.db.entity.Announcement;
+
+public interface AnnouncementRepository extends JpaRepository<Announcement, Integer> {
+}

--- a/src/main/java/site/offload/offloadserver/db/repository/CharacterMotionRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/CharacterMotionRepository.java
@@ -3,5 +3,5 @@ package site.offload.offloadserver.db.repository;
 import org.springframework.data.repository.CrudRepository;
 import site.offload.offloadserver.db.entity.CharacterMotion;
 
-public interface CharacterMotionRepository extends CrudRepository<CharacterMotion, Long> {
+public interface CharacterMotionRepository extends CrudRepository<CharacterMotion, Integer> {
 }

--- a/src/main/java/site/offload/offloadserver/db/repository/CharacterMotionRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/CharacterMotionRepository.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import site.offload.offloadserver.db.entity.CharacterMotion;
+
+public interface CharacterMotionRepository extends CrudRepository<CharacterMotion, Long> {
+}

--- a/src/main/java/site/offload/offloadserver/db/repository/CharacterRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/CharacterRepository.java
@@ -1,7 +1,7 @@
 package site.offload.offloadserver.db.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 import site.offload.offloadserver.db.entity.Character;
 
-public interface CharacterRepository extends JpaRepository<Character, Integer> {
+public interface CharacterRepository extends CrudRepository<Character, Integer> {
 }

--- a/src/main/java/site/offload/offloadserver/db/repository/CharacterRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/CharacterRepository.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.offload.offloadserver.db.entity.Character;
+
+public interface CharacterRepository extends JpaRepository<Character, Integer> {
+}

--- a/src/main/java/site/offload/offloadserver/db/repository/CouponRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import site.offload.offloadserver.db.entity.Coupon;
+
+public interface CouponRepository extends CrudRepository<Coupon, Long> {
+}

--- a/src/main/java/site/offload/offloadserver/db/repository/GainedCharacterRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/GainedCharacterRepository.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.offload.offloadserver.db.entity.GainedCharacter;
+
+public interface GainedCharacterRepository extends JpaRepository<GainedCharacter, Integer> {
+}

--- a/src/main/java/site/offload/offloadserver/db/repository/GainedCharacterRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/GainedCharacterRepository.java
@@ -1,7 +1,7 @@
 package site.offload.offloadserver.db.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 import site.offload.offloadserver.db.entity.GainedCharacter;
 
-public interface GainedCharacterRepository extends JpaRepository<GainedCharacter, Long> {
+public interface GainedCharacterRepository extends CrudRepository<GainedCharacter, Long> {
 }

--- a/src/main/java/site/offload/offloadserver/db/repository/GainedCharacterRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/GainedCharacterRepository.java
@@ -3,5 +3,5 @@ package site.offload.offloadserver.db.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.offload.offloadserver.db.entity.GainedCharacter;
 
-public interface GainedCharacterRepository extends JpaRepository<GainedCharacter, Integer> {
+public interface GainedCharacterRepository extends JpaRepository<GainedCharacter, Long> {
 }

--- a/src/main/java/site/offload/offloadserver/db/repository/GainedCouponRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/GainedCouponRepository.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import site.offload.offloadserver.db.entity.GainedCoupon;
+
+public interface GainedCouponRepository extends CrudRepository<GainedCoupon, Long> {
+}

--- a/src/main/java/site/offload/offloadserver/db/repository/GainedEmblemRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/GainedEmblemRepository.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import site.offload.offloadserver.db.entity.GainedEmblem;
+
+public interface GainedEmblemRepository extends CrudRepository<GainedEmblem, Integer> {
+}

--- a/src/main/java/site/offload/offloadserver/db/repository/MemberRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/MemberRepository.java
@@ -3,5 +3,5 @@ package site.offload.offloadserver.db.repository;
 import org.springframework.data.repository.CrudRepository;
 import site.offload.offloadserver.db.entity.Member;
 
-public interface MemberRepository extends CrudRepository<Member, Integer> {
+public interface MemberRepository extends CrudRepository<Member, Long> {
 }

--- a/src/main/java/site/offload/offloadserver/db/repository/MemberRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import site.offload.offloadserver.db.entity.Member;
+
+public interface MemberRepository extends CrudRepository<Member, Integer> {
+}

--- a/src/main/java/site/offload/offloadserver/db/repository/PlaceRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/PlaceRepository.java
@@ -3,5 +3,5 @@ package site.offload.offloadserver.db.repository;
 import org.springframework.data.repository.CrudRepository;
 import site.offload.offloadserver.db.entity.Place;
 
-public interface PlaceRepository extends CrudRepository<Place, Integer> {
+public interface PlaceRepository extends CrudRepository<Place, Long> {
 }

--- a/src/main/java/site/offload/offloadserver/db/repository/PlaceRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/PlaceRepository.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import site.offload.offloadserver.db.entity.Place;
+
+public interface PlaceRepository extends CrudRepository<Place, Integer> {
+}

--- a/src/main/java/site/offload/offloadserver/db/repository/VisitedPlaceRepositoiry.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/VisitedPlaceRepositoiry.java
@@ -3,5 +3,5 @@ package site.offload.offloadserver.db.repository;
 import org.springframework.data.repository.CrudRepository;
 import site.offload.offloadserver.db.entity.VisitedPlace;
 
-public interface VisitedPlaceRepositoiry extends CrudRepository<VisitedPlace, Integer> {
+public interface VisitedPlaceRepositoiry extends CrudRepository<VisitedPlace, Long> {
 }

--- a/src/main/java/site/offload/offloadserver/db/repository/VisitedPlaceRepositoiry.java
+++ b/src/main/java/site/offload/offloadserver/db/repository/VisitedPlaceRepositoiry.java
@@ -1,0 +1,7 @@
+package site.offload.offloadserver.db.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import site.offload.offloadserver.db.entity.VisitedPlace;
+
+public interface VisitedPlaceRepositoiry extends CrudRepository<VisitedPlace, Integer> {
+}


### PR DESCRIPTION
## 변경사항
- ERD 토대로 Entity 및 Repository 세팅
## 고려사항
- 생성자 Builder 패턴으로 엔티티 생성 로직 통일했습니다
- Column 어노테이션 등을 통해 서비스 요구 사항대로 DB 제약 조건 반영하려고 해봤습니다

## Comment
- 각 엔티티의 생성시간, 업데이트 시간을 저장하기 위해 JPA Auditing을 사용했습니다. (BaseTime 클래스 상속)
- PlaceCategory에 NONE 값을 넣어놨는데, 서비스 요구 사항 중 장소 별 로티 발동 조건이 있으므로 이에 null보단 카테고리 없음을 나타내는 NONE 타입이 있으면 좋을 것 같아 추가했습니다
- 개선해야 할 점, 수정해야 할 점, 추가해야할 데이터 필드 코멘트 부탁드립니다!
## Test
<img width="335" alt="image" src="https://github.com/Team-Offroad/Offroad-server/assets/121341289/e8ace603-698b-4e68-bc89-ce7c19dd772c">

## 질문사항
