### PR TITLE
[feat] 토큰 재발급 API

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/member/controller/TokenController.java
+++ b/src/main/java/site/offload/offloadserver/api/member/controller/TokenController.java
@@ -1,0 +1,30 @@
+package site.offload.offloadserver.api.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.offload.offloadserver.api.member.dto.response.TokenReissueResponse;
+import site.offload.offloadserver.api.member.service.MemberUseCase;
+import site.offload.offloadserver.api.message.SuccessMessage;
+import site.offload.offloadserver.api.response.APISuccessResponse;
+import site.offload.offloadserver.common.auth.PrincipalHandler;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TokenController implements TokenControllerSwagger {
+
+    private final PrincipalHandler principalHandler;
+    private final MemberUseCase memberUseCase;
+
+    @PostMapping("/auth/refresh")
+    public ResponseEntity<APISuccessResponse<TokenReissueResponse>> refreshToken(@RequestHeader("Authorization") String tokenHeaderValue) {
+        final String refreshToken = tokenHeaderValue.substring("Bearer ".length());
+        final Long memberId = principalHandler.getUserIdFromPrincipal();
+        return APISuccessResponse.of(HttpStatus.CREATED.value(), SuccessMessage.ACCESS_TOKEN_REFRESH_SUCCESS.getMessage(), memberUseCase.reissueTokens(memberId, refreshToken));
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/member/controller/TokenControllerSwagger.java
+++ b/src/main/java/site/offload/offloadserver/api/member/controller/TokenControllerSwagger.java
@@ -1,0 +1,19 @@
+package site.offload.offloadserver.api.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestHeader;
+import site.offload.offloadserver.api.member.dto.response.TokenReissueResponse;
+import site.offload.offloadserver.api.response.APISuccessResponse;
+
+public interface TokenControllerSwagger {
+
+    @Operation(summary = "토큰 재발급 API", description = "Refresh Token으로 Access Token, Refresh Token을 재발급하는 API입니다.")
+    @ApiResponse(responseCode = "201",
+            description = "토큰 재발급 완료",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    ResponseEntity<APISuccessResponse<TokenReissueResponse>> refreshToken(@RequestHeader("Authorization") String tokenHeaderValue);
+}

--- a/src/main/java/site/offload/offloadserver/api/member/dto/response/TokenReissueResponse.java
+++ b/src/main/java/site/offload/offloadserver/api/member/dto/response/TokenReissueResponse.java
@@ -1,0 +1,8 @@
+package site.offload.offloadserver.api.member.dto.response;
+
+public record TokenReissueResponse(String accessToken, String refreshToken) {
+
+    public static TokenReissueResponse of(final String accessToken, final String refreshToken) {
+        return new TokenReissueResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/member/service/MemberUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/member/service/MemberUseCase.java
@@ -1,0 +1,32 @@
+package site.offload.offloadserver.api.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import site.offload.offloadserver.api.exception.UnAuthorizedException;
+import site.offload.offloadserver.api.member.dto.response.TokenReissueResponse;
+import site.offload.offloadserver.api.message.ErrorMessage;
+import site.offload.offloadserver.common.jwt.JwtTokenProvider;
+import site.offload.offloadserver.common.jwt.TokenResponse;
+
+@Service
+@RequiredArgsConstructor
+public class MemberUseCase {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public TokenReissueResponse reissueTokens(final Long memberId, final String refreshToken) {
+        if (isRefreshTokenValidate(memberId, refreshToken)) {
+            TokenResponse tokenResponse = jwtTokenProvider.reissueToken(memberId);
+            return TokenReissueResponse.of(tokenResponse.accessToken(), tokenResponse.refreshToken());
+        } else {
+            throw new UnAuthorizedException(ErrorMessage.JWT_REISSUE_EXCEPTION);
+        }
+    }
+
+    private boolean isRefreshTokenValidate(final Long memberId, final String refreshToken) {
+        final String findRefreshToken = redisTemplate.opsForValue().get(String.valueOf(memberId));
+        return refreshToken.equals(findRefreshToken);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/message/CustomErrorCode.java
+++ b/src/main/java/site/offload/offloadserver/api/message/CustomErrorCode.java
@@ -2,5 +2,6 @@ package site.offload.offloadserver.api.message;
 
 public enum CustomErrorCode {
     CUSTOM_ERROR_CODE, // 예시 코드
-    INVALID_AUTHORIZATION_JWT
+    INVALID_AUTHORIZATION_JWT,
+    FAIL_REISSUE_TOKEN
 }

--- a/src/main/java/site/offload/offloadserver/api/message/ErrorMessage.java
+++ b/src/main/java/site/offload/offloadserver/api/message/ErrorMessage.java
@@ -13,6 +13,7 @@ public enum ErrorMessage {
 
     /* 401 UnAuthorized */
     JWT_UNAUTHORIZED_EXCEPTION("사용자 검증을 실패했습니다.",HttpStatus.UNAUTHORIZED, CustomErrorCode.INVALID_AUTHORIZATION_JWT),
+    JWT_REISSUE_EXCEPTION("토큰 재발급에 실패했습니다.", HttpStatus.UNAUTHORIZED, CustomErrorCode.FAIL_REISSUE_TOKEN),
     /* 403 Forbidden */
 
     /* 404 Not Found */

--- a/src/main/java/site/offload/offloadserver/api/message/SuccessMessage.java
+++ b/src/main/java/site/offload/offloadserver/api/message/SuccessMessage.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SuccessMessage {
 
-    SOCIAL_LOGIN_SUCCESS("로그인 요청 성공");
-
+    SOCIAL_LOGIN_SUCCESS("로그인 요청 성공"),
+    ACCESS_TOKEN_REFRESH_SUCCESS("Access Token 재발급 성공");
     private final String message;
 }


### PR DESCRIPTION
## 변경사항
- TokenController, MemberUseCase에 토큰 관련 로직
## 고려사항
- TokenController를 member 패키지 아래에 정의했습니다.
- https://github.com/Team-Offroad/Offroad-server/blob/cdde27e02c5b15f5fc3c0edc088b56ce503ea98e/src/main/java/site/offload/offloadserver/api/member/controller/TokenController.java#L16-L30
--------------------------------------------
- 재발급 로직은 아래와 같습니다.
- https://github.com/Team-Offroad/Offroad-server/blob/cdde27e02c5b15f5fc3c0edc088b56ce503ea98e/src/main/java/site/offload/offloadserver/api/member/service/MemberUseCase.java#L14-L32
## Comment
- Jwt 필터에서 토큰에 대한 검증은 한 번 하기 때문에 서비스 로직에서는 Refresh Token이 Redis에 존재하는지 체크하고, 없다면 예외처리를 해줬습니다.
## Test

## 질문사항

