### PR TITLE
[feat] 칭호 변경 API

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/emblem/controller/EmblemControllSwawgger.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/controller/EmblemControllSwawgger.java
@@ -1,0 +1,18 @@
+package site.offload.offloadserver.api.emblem.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+import site.offload.offloadserver.api.response.APISuccessResponse;
+
+public interface EmblemControllSwawgger {
+
+    @Operation(summary = "유저의 칭호 변경 API", description = "유저의 칭호를 변경하는 API입니다.")
+    @ApiResponse(responseCode = "200",
+            description = "칭호 변경 완료",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    ResponseEntity<APISuccessResponse<Void>> updateEmblem(@RequestParam(value = "emblemCode") final String emblemCode);
+}

--- a/src/main/java/site/offload/offloadserver/api/emblem/controller/EmblemController.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/controller/EmblemController.java
@@ -1,0 +1,31 @@
+package site.offload.offloadserver.api.emblem.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import site.offload.offloadserver.api.emblem.dto.request.UpdateCurrentEmblemRequest;
+import site.offload.offloadserver.api.emblem.usecase.EmblemUseCase;
+import site.offload.offloadserver.api.message.SuccessMessage;
+import site.offload.offloadserver.api.response.APISuccessResponse;
+import site.offload.offloadserver.common.auth.PrincipalHandler;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/emblems")
+public class EmblemController implements EmblemControllSwawgger{
+
+    private final PrincipalHandler principalHandler;
+    private final EmblemUseCase emblemUseCase;
+
+    @PatchMapping
+    public ResponseEntity<APISuccessResponse<Void>> updateEmblem(@RequestParam(value = "emblemCode") final String emblemCode) {
+        final Long memberId = principalHandler.getMemberIdFromPrincipal();
+        emblemUseCase.updateCurrentEmblem(UpdateCurrentEmblemRequest.of(emblemCode, memberId));
+        return APISuccessResponse.of(HttpStatus.OK.value(),
+         SuccessMessage.MEMBER_CURRENT_EMBLEM_UPDATE_SUCCESS.getMessage(), null);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/emblem/dto/request/UpdateCurrentEmblemRequest.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/dto/request/UpdateCurrentEmblemRequest.java
@@ -1,0 +1,8 @@
+package site.offload.offloadserver.api.emblem.dto.request;
+
+public record UpdateCurrentEmblemRequest(String emblemName, Long memberId) {
+
+    public static UpdateCurrentEmblemRequest of(String emblemName, Long memberId) {
+        return new UpdateCurrentEmblemRequest(emblemName, memberId);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/emblem/service/GainedEmblemService.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/service/GainedEmblemService.java
@@ -1,0 +1,18 @@
+package site.offload.offloadserver.api.emblem.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import site.offload.offloadserver.db.emblem.entity.Emblem;
+import site.offload.offloadserver.db.emblem.repository.GainedEmblemRepository;
+import site.offload.offloadserver.db.member.entity.Member;
+
+@Component
+@RequiredArgsConstructor
+public class GainedEmblemService {
+
+    private final GainedEmblemRepository gainedEmblemRepository;
+
+    public boolean isExistsByMemberAndEmblem(Member member, Emblem emblem) {
+        return gainedEmblemRepository.existsByMemberAndEmblemName(member, emblem);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/emblem/usecase/EmblemUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/usecase/EmblemUseCase.java
@@ -1,0 +1,32 @@
+package site.offload.offloadserver.api.emblem.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.offload.offloadserver.api.emblem.dto.request.UpdateCurrentEmblemRequest;
+import site.offload.offloadserver.api.exception.NotFoundException;
+import site.offload.offloadserver.api.member.service.MemberService;
+import site.offload.offloadserver.api.message.ErrorMessage;
+import site.offload.offloadserver.db.emblem.entity.Emblem;
+import site.offload.offloadserver.db.member.entity.Member;
+
+@Service
+@RequiredArgsConstructor
+public class EmblemUseCase {
+
+    private final MemberService memberService;
+
+    @Transactional
+    public void updateCurrentEmblem(UpdateCurrentEmblemRequest request) {
+        if (isExistsEmblem(request.emblemName())) {
+            Member findMember = memberService.findById(request.memberId());
+            findMember.updateEmblem(Emblem.valueOf(request.emblemName()));
+        } else {
+            throw new NotFoundException(ErrorMessage.EMBLEM_NOTFOUND_EXCEPTION);
+        }
+    }
+
+    private boolean isExistsEmblem(String emblemName) {
+        return Emblem.isExistsEmblem(Emblem.valueOf(emblemName));
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/emblem/usecase/EmblemUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/usecase/EmblemUseCase.java
@@ -20,7 +20,7 @@ public class EmblemUseCase {
     public void updateCurrentEmblem(UpdateCurrentEmblemRequest request) {
         if (isExistsEmblem(request.emblemName())) {
             Member findMember = memberService.findById(request.memberId());
-            findMember.updateEmblem(Emblem.valueOf(request.emblemName()));
+            findMember.updateEmblemName(Emblem.valueOf(request.emblemName()));
         } else {
             throw new NotFoundException(ErrorMessage.EMBLEM_NOTFOUND_EXCEPTION);
         }

--- a/src/main/java/site/offload/offloadserver/api/emblem/usecase/EmblemUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/usecase/EmblemUseCase.java
@@ -17,9 +17,9 @@ public class EmblemUseCase {
     private final MemberService memberService;
 
     @Transactional
-    public void updateCurrentEmblem(UpdateCurrentEmblemRequest request) {
+    public void updateCurrentEmblem(final UpdateCurrentEmblemRequest request) {
         if (isExistsEmblem(request.emblemName())) {
-            Member findMember = memberService.findById(request.memberId());
+            final Member findMember = memberService.findById(request.memberId());
             findMember.updateEmblemName(Emblem.valueOf(request.emblemName()));
         } else {
             throw new NotFoundException(ErrorMessage.EMBLEM_NOTFOUND_EXCEPTION);

--- a/src/main/java/site/offload/offloadserver/api/member/controller/MemberController.java
+++ b/src/main/java/site/offload/offloadserver/api/member/controller/MemberController.java
@@ -4,9 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import site.offload.offloadserver.api.member.dto.MemberAdventureInformationRequest;
-import site.offload.offloadserver.api.member.dto.MemberAdventureInformationResponse;
 import site.offload.offloadserver.api.member.dto.request.MemberProfileUpdateRequest;
+import site.offload.offloadserver.api.member.dto.request.MemberAdventureInformationRequest;
+import site.offload.offloadserver.api.member.dto.response.MemberAdventureInformationResponse;
 import site.offload.offloadserver.api.member.usecase.MemberUseCase;
 import site.offload.offloadserver.api.message.SuccessMessage;
 import site.offload.offloadserver.api.response.APISuccessResponse;
@@ -25,7 +25,7 @@ public class MemberController implements MemberControllerSwagger {
                                                                                                           @RequestParam(value = "characterId") final Integer characterId) {
         final Long memberId = principalHandler.getMemberIdFromPrincipal();
         return APISuccessResponse.of(HttpStatus.OK.value(),
-                SuccessMessage.MEMBER_ADVENTURE_INFORMATION_SUCCESS.toString(),
+                SuccessMessage.MEMBER_ADVENTURE_INFORMATION_SUCCESS.getMessage(),
                 memberUseCase.getMemberAdventureInformation(MemberAdventureInformationRequest.of(memberId, category, characterId)));
     }
 

--- a/src/main/java/site/offload/offloadserver/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/site/offload/offloadserver/api/member/controller/MemberControllerSwagger.java
@@ -7,8 +7,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import site.offload.offloadserver.api.member.dto.MemberAdventureInformationResponse;
 import site.offload.offloadserver.api.member.dto.request.MemberProfileUpdateRequest;
+import site.offload.offloadserver.api.member.dto.response.MemberAdventureInformationResponse;
 import site.offload.offloadserver.api.response.APISuccessResponse;
 
 public interface MemberControllerSwagger {

--- a/src/main/java/site/offload/offloadserver/api/member/dto/request/MemberAdventureInformationRequest.java
+++ b/src/main/java/site/offload/offloadserver/api/member/dto/request/MemberAdventureInformationRequest.java
@@ -1,4 +1,4 @@
-package site.offload.offloadserver.api.member.dto;
+package site.offload.offloadserver.api.member.dto.request;
 
 public record MemberAdventureInformationRequest(Long memberId, String category, Integer characterId) {
 

--- a/src/main/java/site/offload/offloadserver/api/member/dto/response/MemberAdventureInformationResponse.java
+++ b/src/main/java/site/offload/offloadserver/api/member/dto/response/MemberAdventureInformationResponse.java
@@ -1,4 +1,4 @@
-package site.offload.offloadserver.api.member.dto;
+package site.offload.offloadserver.api.member.dto.response;
 
 public record MemberAdventureInformationResponse(String nickname, String emblemName, String characterImgUrl,
                                                  String characterName) {

--- a/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
@@ -37,7 +37,7 @@ public class MemberUseCase {
     public MemberAdventureInformationResponse getMemberAdventureInformation(final MemberAdventureInformationRequest request) {
         final Member findMember = memberService.findById(request.memberId());
         final String nickname = findMember.getNickName();
-        final String emblemName = findMember.getCurrentEmblemName().getEmblemName();
+        final String emblemName = findMember.getCurrentEmblemName();
         final Character findCharacter = characterService.findById(request.characterId());
         final PlaceCategory placeCategory = PlaceCategory.valueOf(request.category());
 

--- a/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
@@ -8,8 +8,8 @@ import site.offload.offloadserver.api.characterMotion.service.CharacterMotionSer
 import site.offload.offloadserver.api.characterMotion.service.GainedCharacterMotionService;
 import site.offload.offloadserver.api.exception.NotFoundException;
 import site.offload.offloadserver.api.exception.UnAuthorizedException;
-import site.offload.offloadserver.api.member.dto.MemberAdventureInformationRequest;
-import site.offload.offloadserver.api.member.dto.MemberAdventureInformationResponse;
+import site.offload.offloadserver.api.member.dto.request.MemberAdventureInformationRequest;
+import site.offload.offloadserver.api.member.dto.response.MemberAdventureInformationResponse;
 import site.offload.offloadserver.api.character.service.CharacterService;
 import site.offload.offloadserver.api.member.dto.request.MemberProfileUpdateRequest;
 import site.offload.offloadserver.api.member.dto.response.TokenReissueResponse;
@@ -37,7 +37,7 @@ public class MemberUseCase {
     public MemberAdventureInformationResponse getMemberAdventureInformation(final MemberAdventureInformationRequest request) {
         final Member findMember = memberService.findById(request.memberId());
         final String nickname = findMember.getNickName();
-        final String emblemName = findMember.getCurrentEmblemName();
+        final String emblemName = findMember.getCurrentEmblemName().getEmblemName();
         final Character findCharacter = characterService.findById(request.characterId());
         final PlaceCategory placeCategory = PlaceCategory.valueOf(request.category());
 
@@ -63,7 +63,7 @@ public class MemberUseCase {
         //유저가 획득한 모션인지 확인
         if (isMemberGainedMotion(findCharacterMotion, member)) {
             return findCharacterMotion.getMotionImageUrl();
-            //아니라면 기본 이미지 반환
+        //아니라면 기본 이미지 반환
         } else {
             return character.getCharacterBaseImageUrl();
         }

--- a/src/main/java/site/offload/offloadserver/api/message/CustomErrorCode.java
+++ b/src/main/java/site/offload/offloadserver/api/message/CustomErrorCode.java
@@ -7,5 +7,6 @@ public enum CustomErrorCode {
     NOT_EXISTS_PLACE_CATEGORY, // 존재하지 않은 장소 카테고리
     NOT_EXISTS_CHARACTER, // 존재하지 않는 캐릭터
     NOT_EXISTS_CHARACTER_MOTION, // 존재하지 않는 캐릭터 모션
+    NOT_EXISTS_EMBLEM,
     INVALID_AUTHORIZATION_JWT;
 }

--- a/src/main/java/site/offload/offloadserver/api/message/CustomErrorCode.java
+++ b/src/main/java/site/offload/offloadserver/api/message/CustomErrorCode.java
@@ -8,5 +8,6 @@ public enum CustomErrorCode {
     NOT_EXISTS_CHARACTER, // 존재하지 않는 캐릭터
     NOT_EXISTS_CHARACTER_MOTION, // 존재하지 않는 캐릭터 모션
     NOT_EXISTS_EMBLEM,
-    INVALID_AUTHORIZATION_JWT;
+    INVALID_AUTHORIZATION_JWT,
+    FAIL_EMBLEM_UPDATE;
 }

--- a/src/main/java/site/offload/offloadserver/api/message/ErrorMessage.java
+++ b/src/main/java/site/offload/offloadserver/api/message/ErrorMessage.java
@@ -21,7 +21,7 @@ public enum ErrorMessage {
     CHARACTER_NOTFOUND_EXCEPTION("해당 ID의 캐릭터가 존재하지 않습니다.", HttpStatus.NOT_FOUND, CustomErrorCode.NOT_EXISTS_CHARACTER),
     PLACE_CATEGORY_NOTFOUND_EXCEPTION("존재하지 않는 카테고리 유형입니다.", HttpStatus.NOT_FOUND, CustomErrorCode.NOT_EXISTS_PLACE_CATEGORY),
     CHARACTER_MOTION_NOTFOUND_EXCEPTION("캐릭터 모션이 존재하지 않습니다", HttpStatus.NOT_FOUND, CustomErrorCode.NOT_EXISTS_CHARACTER_MOTION),
-
+    EMBLEM_NOTFOUND_EXCEPTION("칭호가 존재하지 않습니다.", HttpStatus.NOT_FOUND, CustomErrorCode.NOT_EXISTS_EMBLEM),
     /* 500 Internal Server Error */
     ERROR_MESSAGE("example",HttpStatus.INTERNAL_SERVER_ERROR, CustomErrorCode.CUSTOM_ERROR_CODE);
     private final String message;

--- a/src/main/java/site/offload/offloadserver/api/message/ErrorMessage.java
+++ b/src/main/java/site/offload/offloadserver/api/message/ErrorMessage.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
 
     /* 400 Bad Request */
-
+    MEMBER_EMBLEM_UPDATE_EXCEPTION("사용자가 얻은 칭호가 아닙니다.", HttpStatus.BAD_REQUEST, CustomErrorCode.FAIL_EMBLEM_UPDATE),
     /* 401 UnAuthorized */
     JWT_UNAUTHORIZED_EXCEPTION("사용자 검증을 실패했습니다.",HttpStatus.UNAUTHORIZED, CustomErrorCode.INVALID_AUTHORIZATION_JWT),
     JWT_REISSUE_EXCEPTION("토큰 재발급에 실패했습니다.", HttpStatus.UNAUTHORIZED, CustomErrorCode.FAIL_REISSUE_TOKEN),

--- a/src/main/java/site/offload/offloadserver/api/message/SuccessMessage.java
+++ b/src/main/java/site/offload/offloadserver/api/message/SuccessMessage.java
@@ -13,8 +13,7 @@ public enum SuccessMessage {
     MEMBER_ADVENTURE_INFORMATION_SUCCESS("모험 정보 조회 성공"),
     CHECK_REGISTERED_PLACES_SUCCESS("장소 리스트 정보 조회 성공"),
     MEMBER_PROFILE_UPDATE_SUCCESS("프로필 업데이트 성공"),
-    CHECK_DUPLICATED_NICKNAME("닉네임 중복 확인 완료");
-
-
+    CHECK_DUPLICATED_NICKNAME("닉네임 중복 확인 완료"),
+    MEMBER_CURRENT_EMBLEM_UPDATE_SUCCESS("칭호 변경 성공");
     private final String message;
 }

--- a/src/main/java/site/offload/offloadserver/db/emblem/entity/Emblem.java
+++ b/src/main/java/site/offload/offloadserver/db/emblem/entity/Emblem.java
@@ -12,7 +12,7 @@ public enum Emblem  {
     private final String emblemCodeName;
     private final String emblemName;
 
-    public static boolean isExistsEmblem(Emblem emblem) {
+    public static boolean isExistsEmblem(final Emblem emblem) {
         for (Emblem thisEmblem : Emblem.values()) {
             if (emblem.equals(thisEmblem)) {
                 return true;

--- a/src/main/java/site/offload/offloadserver/db/emblem/entity/Emblem.java
+++ b/src/main/java/site/offload/offloadserver/db/emblem/entity/Emblem.java
@@ -1,11 +1,23 @@
 package site.offload.offloadserver.db.emblem.entity;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 //칭호
 @RequiredArgsConstructor
+@Getter
 public enum Emblem  {
-    //예시 칭호
-    EMBLEM_CODE("EMBLEM001");
+
+    DEFAULT_EMBLEM("0001", "오프로드 스타터");
     private final String emblemCodeName;
+    private final String emblemName;
+
+    public static boolean isExistsEmblem(Emblem emblem) {
+        for (Emblem thisEmblem : Emblem.values()) {
+            if (emblem.equals(thisEmblem)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/site/offload/offloadserver/db/emblem/repository/GainedEmblemRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/emblem/repository/GainedEmblemRepository.java
@@ -1,7 +1,11 @@
 package site.offload.offloadserver.db.emblem.repository;
 
 import org.springframework.data.repository.CrudRepository;
+import site.offload.offloadserver.db.emblem.entity.Emblem;
 import site.offload.offloadserver.db.emblem.entity.GainedEmblem;
+import site.offload.offloadserver.db.member.entity.Member;
 
 public interface GainedEmblemRepository extends CrudRepository<GainedEmblem, Integer> {
+
+    boolean existsByMemberAndEmblemName(Member member, Emblem emblem);
 }

--- a/src/main/java/site/offload/offloadserver/db/member/entity/Member.java
+++ b/src/main/java/site/offload/offloadserver/db/member/entity/Member.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import site.offload.offloadserver.api.member.dto.request.MemberProfileUpdateRequest;
 import site.offload.offloadserver.api.member.dto.request.SocialPlatform;
 import site.offload.offloadserver.db.BaseTimeEntity;
+import site.offload.offloadserver.db.emblem.entity.Emblem;
 import site.offload.offloadserver.db.member.embeddable.Birthday;
 
 //로그인 유저
@@ -17,7 +18,7 @@ import site.offload.offloadserver.db.member.embeddable.Birthday;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
-    private static final String DEFAULT_EMBLEM_NAME = "오프로드 스타터";
+    private static final Emblem DEFAULT_EMBLEM_NAME = Emblem.DEFAULT_EMBLEM;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,7 +49,8 @@ public class Member extends BaseTimeEntity {
     private String sub;
 
     @Column(nullable = false)
-    private String currentEmblemName = DEFAULT_EMBLEM_NAME;
+    @Enumerated(EnumType.STRING)
+    private Emblem currentEmblemName = DEFAULT_EMBLEM_NAME;
 
     @Enumerated(EnumType.STRING)
     private SocialPlatform socialPlatform;
@@ -81,5 +83,8 @@ public class Member extends BaseTimeEntity {
         this.gender = memberProfileUpdateRequest.gender();
     }
 
+    public void updateEmblem(Emblem emblem) {
+        this.currentEmblemName = emblem;
+    }
 
 }

--- a/src/main/java/site/offload/offloadserver/db/member/entity/Member.java
+++ b/src/main/java/site/offload/offloadserver/db/member/entity/Member.java
@@ -18,7 +18,7 @@ import site.offload.offloadserver.db.member.embeddable.Birthday;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
-    private static final Emblem DEFAULT_EMBLEM_NAME = Emblem.DEFAULT_EMBLEM;
+    private static final String DEFAULT_EMBLEM_NAME = Emblem.DEFAULT_EMBLEM.getEmblemName();
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -50,7 +50,7 @@ public class Member extends BaseTimeEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private Emblem currentEmblemName = DEFAULT_EMBLEM_NAME;
+    private String currentEmblemName = DEFAULT_EMBLEM_NAME;
 
     @Enumerated(EnumType.STRING)
     private SocialPlatform socialPlatform;
@@ -83,8 +83,8 @@ public class Member extends BaseTimeEntity {
         this.gender = memberProfileUpdateRequest.gender();
     }
 
-    public void updateEmblem(Emblem emblem) {
-        this.currentEmblemName = emblem;
+    public void updateEmblemName(Emblem emblem) {
+        this.currentEmblemName = emblem.getEmblemName();
     }
 
 }


### PR DESCRIPTION
## 변경사항
- EmblemController, UseCase 작성, Emblem 클래스 수정, 관련 에러메세지 및 성공 메시지 추가
## 고려사항
- Emblem 클래스에서 칭호가 있는지 없는지 판단하는 메소드 추가했습니다.
```java
@RequiredArgsConstructor
@Getter
public enum Emblem  {

    DEFAULT_EMBLEM("0001", "오프로드 스타터");
    private final String emblemCodeName;
    private final String emblemName;

    public static boolean isExistsEmblem(Emblem emblem) {
        for (Emblem thisEmblem : Emblem.values()) {
            if (emblem.equals(thisEmblem)) {
                return true;
            }
        }
        return false;
    }
}
````
--------------------------------------------------------------------
- EmblemUseCase에서 칭호를 변경하는 메소드를 추가했습니다. 칭호가 존재하지 않으면 에러를 반환합니다.
```java
    @Transactional
    public void updateCurrentEmblem(UpdateCurrentEmblemRequest request) {
        if (isExistsEmblem(request.emblemName())) {
            Member findMember = memberService.findById(request.memberId());
            findMember.updateEmblemName(Emblem.valueOf(request.emblemName()));
        } else {
            throw new NotFoundException(ErrorMessage.EMBLEM_NOTFOUND_EXCEPTION);
        }
    }
```
## Comment

