### PR TITLE
[feat] 칭호 조회 API

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/emblem/controller/EmblemControllSwawgger.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/controller/EmblemControllSwawgger.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
+import site.offload.offloadserver.api.emblem.dto.response.GainedEmblemListResponse;
 import site.offload.offloadserver.api.response.APISuccessResponse;
 
 public interface EmblemControllSwawgger {
@@ -15,4 +16,10 @@ public interface EmblemControllSwawgger {
             description = "칭호 변경 완료",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
     ResponseEntity<APISuccessResponse<Void>> updateEmblem(@RequestParam(value = "emblemCode") final String emblemCode);
+
+    @Operation(summary = "얻은 칭호 조회 API", description = "유저가 획득한 칭호를 조회하는 API 입니다.")
+    @ApiResponse(responseCode = "200",
+            description = "칭호 조회 완료",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    ResponseEntity<APISuccessResponse<GainedEmblemListResponse>> getGainedEmblem();
 }

--- a/src/main/java/site/offload/offloadserver/api/emblem/controller/EmblemController.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/controller/EmblemController.java
@@ -3,11 +3,9 @@ package site.offload.offloadserver.api.emblem.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import site.offload.offloadserver.api.emblem.dto.request.UpdateCurrentEmblemRequest;
+import site.offload.offloadserver.api.emblem.dto.response.GainedEmblemListResponse;
 import site.offload.offloadserver.api.emblem.usecase.EmblemUseCase;
 import site.offload.offloadserver.api.message.SuccessMessage;
 import site.offload.offloadserver.api.response.APISuccessResponse;
@@ -27,5 +25,12 @@ public class EmblemController implements EmblemControllSwawgger{
         emblemUseCase.updateCurrentEmblem(UpdateCurrentEmblemRequest.of(emblemCode, memberId));
         return APISuccessResponse.of(HttpStatus.OK.value(),
          SuccessMessage.MEMBER_CURRENT_EMBLEM_UPDATE_SUCCESS.getMessage(), null);
+    }
+
+    @GetMapping
+    public ResponseEntity<APISuccessResponse<GainedEmblemListResponse>> getGainedEmblem() {
+        final Long memberId = principalHandler.getMemberIdFromPrincipal();
+        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_GAINED_EMBLEM_SUCCESS.getMessage(),
+                                     emblemUseCase.getGainedEmblems(memberId));
     }
 }

--- a/src/main/java/site/offload/offloadserver/api/emblem/dto/response/GainedEmblemListResponse.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/dto/response/GainedEmblemListResponse.java
@@ -1,0 +1,9 @@
+package site.offload.offloadserver.api.emblem.dto.response;
+
+import java.util.List;
+
+public record GainedEmblemListResponse(List<GainedEmblemResponse> emblems) {
+    public static GainedEmblemListResponse of(List<GainedEmblemResponse> emblems) {
+        return new GainedEmblemListResponse(emblems);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/emblem/dto/response/GainedEmblemResponse.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/dto/response/GainedEmblemResponse.java
@@ -1,0 +1,9 @@
+package site.offload.offloadserver.api.emblem.dto.response;
+
+
+public record GainedEmblemResponse(String emblemCode, String emblemName) {
+
+    public static GainedEmblemResponse of(String emblemCode, String emblemName) {
+        return new GainedEmblemResponse(emblemCode, emblemName);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/emblem/service/GainedEmblemService.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/service/GainedEmblemService.java
@@ -3,8 +3,11 @@ package site.offload.offloadserver.api.emblem.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import site.offload.offloadserver.db.emblem.entity.Emblem;
+import site.offload.offloadserver.db.emblem.entity.GainedEmblem;
 import site.offload.offloadserver.db.emblem.repository.GainedEmblemRepository;
 import site.offload.offloadserver.db.member.entity.Member;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -14,5 +17,9 @@ public class GainedEmblemService {
 
     public boolean isExistsByMemberAndEmblem(Member member, Emblem emblem) {
         return gainedEmblemRepository.existsByMemberAndEmblemName(member, emblem);
+    }
+
+    public List<GainedEmblem> findAllByMemberId(Long memberId) {
+        return gainedEmblemRepository.findAllByMemberId(memberId);
     }
 }

--- a/src/main/java/site/offload/offloadserver/api/emblem/usecase/EmblemUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/usecase/EmblemUseCase.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.offload.offloadserver.api.emblem.dto.request.UpdateCurrentEmblemRequest;
+import site.offload.offloadserver.api.emblem.dto.response.GainedEmblemListResponse;
+import site.offload.offloadserver.api.emblem.dto.response.GainedEmblemResponse;
 import site.offload.offloadserver.api.emblem.service.GainedEmblemService;
 import site.offload.offloadserver.api.exception.BadRequestException;
 import site.offload.offloadserver.api.exception.NotFoundException;
@@ -37,5 +39,12 @@ public class EmblemUseCase {
 
     private boolean isExistsEmblem(String emblemName) {
         return Emblem.isExistsEmblem(Emblem.valueOf(emblemName));
+    }
+
+    @Transactional(readOnly = true)
+    public GainedEmblemListResponse getGainedEmblems(Long memberId) {
+        return GainedEmblemListResponse.of(gainedEmblemService.findAllByMemberId(memberId).stream().map(
+                gainedEmblem -> GainedEmblemResponse.of(gainedEmblem.getEmblemName().getEmblemCodeName(),
+                        gainedEmblem.getEmblemName().getEmblemName())).toList());
     }
 }

--- a/src/main/java/site/offload/offloadserver/api/message/SuccessMessage.java
+++ b/src/main/java/site/offload/offloadserver/api/message/SuccessMessage.java
@@ -14,7 +14,8 @@ public enum SuccessMessage {
     CHECK_REGISTERED_PLACES_SUCCESS("장소 리스트 정보 조회 성공"),
     MEMBER_PROFILE_UPDATE_SUCCESS("프로필 업데이트 성공"),
     CHECK_DUPLICATED_NICKNAME("닉네임 중복 확인 완료"),
-    MEMBER_CURRENT_EMBLEM_UPDATE_SUCCESS("칭호 변경 성공");
-    CHOOSE_CHARACTER_SUCCESS("캐릭터 선택 완료");
+    MEMBER_CURRENT_EMBLEM_UPDATE_SUCCESS("칭호 변경 성공"),
+    CHOOSE_CHARACTER_SUCCESS("캐릭터 선택 완료"),
+    GET_GAINED_EMBLEM_SUCCESS("칭호 조회 완료");
     private final String message;
 }

--- a/src/main/java/site/offload/offloadserver/db/emblem/entity/GainedEmblem.java
+++ b/src/main/java/site/offload/offloadserver/db/emblem/entity/GainedEmblem.java
@@ -2,6 +2,7 @@ package site.offload.offloadserver.db.emblem.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.offload.offloadserver.db.member.entity.Member;
 
@@ -11,6 +12,7 @@ import site.offload.offloadserver.db.member.entity.Member;
 @Table(uniqueConstraints = {
         @UniqueConstraint(columnNames = {"member_id", "emblemName"})
 })
+@Getter
 public class GainedEmblem {
 
     @Id

--- a/src/main/java/site/offload/offloadserver/db/emblem/repository/GainedEmblemRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/emblem/repository/GainedEmblemRepository.java
@@ -5,7 +5,11 @@ import site.offload.offloadserver.db.emblem.entity.Emblem;
 import site.offload.offloadserver.db.emblem.entity.GainedEmblem;
 import site.offload.offloadserver.db.member.entity.Member;
 
+import java.util.List;
+
 public interface GainedEmblemRepository extends CrudRepository<GainedEmblem, Integer> {
 
     boolean existsByMemberAndEmblemName(Member member, Emblem emblem);
+
+    List<GainedEmblem> findAllByMemberId(Long memberId);
 }


### PR DESCRIPTION
## 변경사항
- EmblemController 수정
----------------------------------
- 칭호 조회에 필요한 DTO 클래스 정의
- https://github.com/Team-Offroad/Offroad-server/blob/595ba5b5041b15f66daeee4284c263544751542b/src/main/java/site/offload/offloadserver/api/emblem/dto/response/GainedEmblemListResponse.java#L5-L9
- https://github.com/Team-Offroad/Offroad-server/blob/595ba5b5041b15f66daeee4284c263544751542b/src/main/java/site/offload/offloadserver/api/emblem/dto/response/GainedEmblemResponse.java#L4-L9
------------------------------------------
- EmblemUseCase 로직 추가
- https://github.com/Team-Offroad/Offroad-server/blob/595ba5b5041b15f66daeee4284c263544751542b/src/main/java/site/offload/offloadserver/api/emblem/usecase/EmblemUseCase.java#L44-L50
## 고려사항
- 멤버가 얻은 칭호를 반환하도록 했습니다
- Repository에서는 List 형태로 반환하도록 해서 값이 없다면 null이 아닌 빈 리스트를 반환하도록 했습니다.
## Comment

## Test

## 질문사항

