### PR TITLE
[fix] : 구글 소셜 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/site/offload/offloadserver/OffloadserverApplication.java
+++ b/src/main/java/site/offload/offloadserver/OffloadserverApplication.java
@@ -2,8 +2,10 @@ package site.offload.offloadserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class OffloadserverApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/site/offload/offloadserver/common/auth/SecurityConfig.java
+++ b/src/main/java/site/offload/offloadserver/common/auth/SecurityConfig.java
@@ -27,7 +27,9 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/v2/api-docs/**",
             "/swagger-resources/**",
-            "/api/health"};
+            "/api/health",
+            "/oauth/google/**"
+    };
 
     @Bean
     @Profile("dev")

--- a/src/main/java/site/offload/offloadserver/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/site/offload/offloadserver/common/jwt/JwtTokenProvider.java
@@ -66,8 +66,8 @@ public class JwtTokenProvider {
                 .compact();
 
         redisTemplate.opsForValue().set(
-                String.valueOf(memberId),
                 refreshToken,
+                String.valueOf(memberId),
                 REFRESH_TOKEN_EXPIRATION_TIME,
                 TimeUnit.MILLISECONDS
         );

--- a/src/main/java/site/offload/offloadserver/external/oauth/google/request/GoogleApiClient.java
+++ b/src/main/java/site/offload/offloadserver/external/oauth/google/request/GoogleApiClient.java
@@ -1,0 +1,15 @@
+package site.offload.offloadserver.external.oauth.google.request;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import site.offload.offloadserver.external.oauth.google.response.GoogleInfoResponse;
+
+@FeignClient(value = "googleClient", url = "https://www.googleapis.com/userinfo/v2/me")
+public interface GoogleApiClient {
+
+    @GetMapping
+    GoogleInfoResponse googleInfo(
+            @RequestHeader("Authorization") String token
+    );
+}

--- a/src/main/java/site/offload/offloadserver/external/oauth/google/request/GoogleAuthApiClient.java
+++ b/src/main/java/site/offload/offloadserver/external/oauth/google/request/GoogleAuthApiClient.java
@@ -1,0 +1,18 @@
+package site.offload.offloadserver.external.oauth.google.request;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import site.offload.offloadserver.external.oauth.google.response.GoogleAuthResponse;
+
+@FeignClient(name = "GoogleAuthApiClient", url = "https://oauth2.googleapis.com/token")
+public interface GoogleAuthApiClient {
+
+    @PostMapping
+    GoogleAuthResponse googleAuth(
+            @RequestParam(name = "code") String code,
+            @RequestParam(name = "client_id") String clientId,
+            @RequestParam(name = "client_secret") String clientSecret,
+            @RequestParam(name = "redirect_uri") String redirectUri,
+            @RequestParam(name = "grant_type") String grantType);
+}

--- a/src/main/java/site/offload/offloadserver/external/oauth/google/response/GoogleAuthResponse.java
+++ b/src/main/java/site/offload/offloadserver/external/oauth/google/response/GoogleAuthResponse.java
@@ -6,9 +6,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public record GoogleAuthResponse(
         String accessToken,
-        String refreshToken
+        String scope,
+        String id_token
 ) {
-    public static GoogleAuthResponse of(String accessToken, String refreshToken){
-        return new GoogleAuthResponse(accessToken, refreshToken);
+    public static GoogleAuthResponse of(String accessToken, String scope, String id_token){
+        return new GoogleAuthResponse(accessToken, scope, id_token);
     }
 }

--- a/src/main/java/site/offload/offloadserver/external/oauth/google/response/GoogleInfoResponse.java
+++ b/src/main/java/site/offload/offloadserver/external/oauth/google/response/GoogleInfoResponse.java
@@ -5,16 +5,11 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record GoogleInfoResponse(
-        String sub,
+        String id,
         String name,
-        String givenName,
-        String familyName,
-        String picture,
-        String email,
-        Boolean emailVerified,
-        String locale
+        String email
 ) {
-    public static GoogleInfoResponse of(String sub, String name, String givenName, String familyName, String picture, String email, Boolean emailVerified, String locale){
-        return new GoogleInfoResponse(sub, name, givenName, familyName, picture, email, emailVerified, locale);
+    public static GoogleInfoResponse of(String id, String name, String email){
+        return new GoogleInfoResponse(id, name, email);
     }
 }


### PR DESCRIPTION
## 변경사항

### redis 저장

https://github.com/Team-Offroad/Offroad-server/blob/e35a966f325a5b43f0bfe80c564d91e3e0c6819e/src/main/java/site/offload/offloadserver/common/jwt/JwtTokenProvider.java#L68-L73

* redis에 저장할 때 key를 refreshtoken으로 설정했습니다.

https://github.com/Team-Offroad/Offroad-server/blob/e35a966f325a5b43f0bfe80c564d91e3e0c6819e/src/main/java/site/offload/offloadserver/external/oauth/google/GoogleSocialLoginService.java#L35-L47

https://github.com/Team-Offroad/Offroad-server/blob/e35a966f325a5b43f0bfe80c564d91e3e0c6819e/src/main/java/site/offload/offloadserver/external/oauth/google/response/GoogleInfoResponse.java#L6-L15

* RestClient에서 OpenFeign으로 변경하여 구글 소셜 로그인을 구현했습니다.
* /v2/me 엔드포인트는 구글 개인 id가 "sub"가 아닌 "id"로 전송해서 DTO의 이름을 id로 수정했습니다.


## Test

<img width="798" alt="image" src="https://github.com/user-attachments/assets/3441d3d7-1241-46a8-a1dd-472af41623d2">
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/9eeb4880-af9f-4e9f-aa83-1439bb88fe68">


