### PR TITLE
[fix] 얻은 캐릭터 모션 리포 생성 및 모험 정보 APi 수정

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/charactermotion/service/GainedCharacterMotionService.java
+++ b/src/main/java/site/offload/offloadserver/api/charactermotion/service/GainedCharacterMotionService.java
@@ -2,17 +2,17 @@ package site.offload.offloadserver.api.charactermotion.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import site.offload.offloadserver.db.character.repository.GainedCharacterRepository;
 import site.offload.offloadserver.db.charactermotion.entity.CharacterMotion;
+import site.offload.offloadserver.db.charactermotion.repository.GainedCharacterMotionRepository;
 import site.offload.offloadserver.db.member.entity.Member;
 
 @Component
 @RequiredArgsConstructor
 public class GainedCharacterMotionService {
 
-    private final GainedCharacterRepository gainedCharacterRepository;
+    private final GainedCharacterMotionRepository gainedCharacterMotionRepository;
 
     public boolean isExistByCharacterMotionAndMember(CharacterMotion characterMotion, Member member) {
-        return gainedCharacterRepository.existsByCharacterAndMember(characterMotion, member);
+        return gainedCharacterMotionRepository.existsByCharacterMotionAndMember(characterMotion, member);
     }
 }

--- a/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
@@ -61,7 +61,7 @@ public class MemberUseCase {
         final Character findCharacter = characterService.findById(request.characterId());
         final PlaceCategory placeCategory = PlaceCategory.valueOf(request.category());
 
-        if (PlaceCategory.isExistsCategory(placeCategory)) {
+        if (!PlaceCategory.isExistsCategory(placeCategory)) {
             throw new NotFoundException(ErrorMessage.PLACE_CATEGORY_NOTFOUND_EXCEPTION);
         }
 

--- a/src/main/java/site/offload/offloadserver/db/charactermotion/repository/GainedCharacterMotionRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/charactermotion/repository/GainedCharacterMotionRepository.java
@@ -1,0 +1,10 @@
+package site.offload.offloadserver.db.charactermotion.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import site.offload.offloadserver.db.charactermotion.entity.CharacterMotion;
+import site.offload.offloadserver.db.charactermotion.entity.GainedCharacterMotion;
+import site.offload.offloadserver.db.member.entity.Member;
+
+public interface GainedCharacterMotionRepository extends CrudRepository<GainedCharacterMotion, Long> {
+    boolean existsByCharacterMotionAndMember(CharacterMotion characterMotion, Member member);
+}


### PR DESCRIPTION
## 변경사항
- GaiendCharacterMotionService에서 GainedCharacterRepository -> GainedCharacterMotionRepository로 수정
- MemberUseCase에서 if문 조건 수정
```java
        if (!PlaceCategory.isExistsCategory(placeCategory)) {
            throw new NotFoundException(ErrorMessage.PLACE_CATEGORY_NOTFOUND_EXCEPTION);
        }
```

