### PR TITLE
[fix] 멤버 회원가입시 기본 칭호 GainedEmblem db에 추가

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/emblem/service/GainedEmblemService.java
+++ b/src/main/java/site/offload/offloadserver/api/emblem/service/GainedEmblemService.java
@@ -22,4 +22,8 @@ public class GainedEmblemService {
     public List<GainedEmblem> findAllByMemberId(Long memberId) {
         return gainedEmblemRepository.findAllByMemberId(memberId);
     }
+
+    public Integer save(Member member, String emblemCode) {
+        return gainedEmblemRepository.save(GainedEmblem.create(member, emblemCode)).getId();
+    }
 }

--- a/src/main/java/site/offload/offloadserver/db/emblem/entity/GainedEmblem.java
+++ b/src/main/java/site/offload/offloadserver/db/emblem/entity/GainedEmblem.java
@@ -25,4 +25,13 @@ public class GainedEmblem {
 
     @Column(nullable = false)
     private String emblemCode;
+
+    private GainedEmblem(Member member, String emblemCode) {
+        this.member = member;
+        this.emblemCode = emblemCode;
+    }
+
+    public static GainedEmblem create(Member member, String emblemCode) {
+        return new GainedEmblem(member, emblemCode);
+    }
 }


### PR DESCRIPTION
## 변경사항
- SocialLoginService
## 고려사항
- 유저가 회원가입 시 기본 칭호를 얻게 했습니다. -> GainedEmblem 테이블 컬럼 추가
- 로그인 요청이 여러 번 오기 때문에 DB에 exists 쿼리로 확인 후 저장합니다.


