### PR TITLE
[fix] 모험 정보 조회 API에서 characterId 요청 이슈

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/character/service/CharacterService.java
+++ b/src/main/java/site/offload/offloadserver/api/character/service/CharacterService.java
@@ -24,4 +24,10 @@ public class CharacterService {
     public List<Character> findAll() {
         return characterRepository.findAll();
     }
+
+    public Character findByName(final String name) {
+        return characterRepository.findByName(name).orElseThrow(
+                ()  -> new NotFoundException(ErrorMessage.CHARACTER_NOTFOUND_EXCEPTION)
+        );
+    }
 }

--- a/src/main/java/site/offload/offloadserver/api/member/controller/MemberController.java
+++ b/src/main/java/site/offload/offloadserver/api/member/controller/MemberController.java
@@ -22,12 +22,12 @@ public class MemberController implements MemberControllerSwagger {
     private final MemberUseCase memberUseCase;
 
     @GetMapping("/adventures/informations")
-    public ResponseEntity<APISuccessResponse<MemberAdventureInformationResponse>> getAdventureInformation(@RequestParam(value = "category") final String category,
-                                                                                                          @RequestParam(value = "characterId") final Integer characterId) {
+    public ResponseEntity<APISuccessResponse<MemberAdventureInformationResponse>> getAdventureInformation(@RequestParam(value = "category") final String category
+    ) {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         return APISuccessResponse.of(HttpStatus.OK.value(),
                 SuccessMessage.MEMBER_ADVENTURE_INFORMATION_SUCCESS.getMessage(),
-                memberUseCase.getMemberAdventureInformation(MemberAdventureInformationRequest.of(memberId, category, characterId)));
+                memberUseCase.getMemberAdventureInformation(MemberAdventureInformationRequest.of(memberId, category)));
     }
 
     @PatchMapping("/profiles")

--- a/src/main/java/site/offload/offloadserver/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/site/offload/offloadserver/api/member/controller/MemberControllerSwagger.java
@@ -20,8 +20,8 @@ public interface MemberControllerSwagger {
     @ApiResponse(responseCode = "200",
             description = "모험 인증 정보 요청 성공",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    ResponseEntity<APISuccessResponse<MemberAdventureInformationResponse>> getAdventureInformation(@RequestParam(value = "category") final String category,
-                                                                                                   @RequestParam(value = "characterId") final Integer characterId);
+    ResponseEntity<APISuccessResponse<MemberAdventureInformationResponse>> getAdventureInformation(@RequestParam(value = "category") final String category
+    );
 
     @Operation(summary = "프로필 업데이트 API", description = "프로필 업데이트 정보를 받아 멤버 업데이트")
     @ApiResponse(responseCode = "200",
@@ -48,7 +48,7 @@ public interface MemberControllerSwagger {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
     ResponseEntity<APISuccessResponse<AuthAdventureResponse>> authAdventure(final @RequestBody AuthAdventureRequest request);
 
-    }
+}
 
 
 

--- a/src/main/java/site/offload/offloadserver/api/member/dto/request/MemberAdventureInformationRequest.java
+++ b/src/main/java/site/offload/offloadserver/api/member/dto/request/MemberAdventureInformationRequest.java
@@ -1,8 +1,8 @@
 package site.offload.offloadserver.api.member.dto.request;
 
-public record MemberAdventureInformationRequest(Long memberId, String category, Integer characterId) {
+public record MemberAdventureInformationRequest(Long memberId, String category) {
 
-    public static MemberAdventureInformationRequest of(final Long memberId, final String category, final Integer characterId) {
-        return new MemberAdventureInformationRequest(memberId, category, characterId);
+    public static MemberAdventureInformationRequest of(final Long memberId, final String category) {
+        return new MemberAdventureInformationRequest(memberId, category);
     }
 }

--- a/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
@@ -66,7 +66,7 @@ public class MemberUseCase {
         final Member findMember = memberService.findById(request.memberId());
         final String nickname = findMember.getNickName();
         final String emblemName = findMember.getCurrentEmblemName();
-        final Character findCharacter = characterService.findById(request.characterId());
+        final Character findCharacter = characterService.findByName(findMember.getCurrentCharacterName());
 
         // 사용자가 획득한 캐릭터인지 확인
         if (!gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(findMember, findCharacter)) {

--- a/src/main/java/site/offload/offloadserver/db/character/repository/CharacterRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/character/repository/CharacterRepository.java
@@ -1,8 +1,10 @@
 package site.offload.offloadserver.db.character.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.CrudRepository;
 import site.offload.offloadserver.db.character.entity.Character;
 
+import java.util.Optional;
+
 public interface CharacterRepository extends JpaRepository<Character, Integer> {
+     Optional<Character> findByName(String name);
 }


### PR DESCRIPTION
## 변경사항
- 모험 정보 조회 API에서, 파라미터로 받던 characterId를 삭제했습니다.
- 이유는 이슈 내용에 적어놨습니다! #97  
## 고려사항
- 현재 유저가 선택한 캐릭터 이름으로 캐릭터에 대한 정보를 가져왔습니다
## Test
<img width="583" alt="image" src="https://github.com/user-attachments/assets/b55243f2-fb48-4d85-9c7b-b123aecafb22">
