### PR TITLE
[hotfix] : 모션보상 관련 퀘스트 일부 저장

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/charactermotion/service/GainedCharacterMotionService.java
+++ b/src/main/java/site/offload/offloadserver/api/charactermotion/service/GainedCharacterMotionService.java
@@ -3,6 +3,7 @@ package site.offload.offloadserver.api.charactermotion.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import site.offload.offloadserver.db.charactermotion.entity.CharacterMotion;
+import site.offload.offloadserver.db.charactermotion.entity.GainedCharacterMotion;
 import site.offload.offloadserver.db.charactermotion.repository.GainedCharacterMotionRepository;
 import site.offload.offloadserver.db.member.entity.Member;
 
@@ -14,5 +15,13 @@ public class GainedCharacterMotionService {
 
     public boolean isExistByCharacterMotionAndMember(CharacterMotion characterMotion, Member member) {
         return gainedCharacterMotionRepository.existsByCharacterMotionAndMember(characterMotion, member);
+    }
+
+    public void save(Member member, CharacterMotion characterMotion) {
+        gainedCharacterMotionRepository.save(
+                GainedCharacterMotion.builder()
+                        .member(member)
+                        .characterMotion(characterMotion)
+                        .build());
     }
 }

--- a/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
@@ -21,7 +21,9 @@ import site.offload.offloadserver.api.member.service.MemberService;
 import site.offload.offloadserver.api.message.ErrorMessage;
 import site.offload.offloadserver.api.place.service.PlaceService;
 import site.offload.offloadserver.api.place.service.VisitedPlaceService;
+import site.offload.offloadserver.api.quest.service.CompleteQuestService;
 import site.offload.offloadserver.api.quest.service.ProceedingQuestService;
+import site.offload.offloadserver.api.quest.service.QuestRewardService;
 import site.offload.offloadserver.api.quest.service.QuestService;
 import site.offload.offloadserver.common.jwt.JwtTokenProvider;
 import site.offload.offloadserver.common.jwt.TokenResponse;
@@ -34,6 +36,8 @@ import site.offload.offloadserver.db.place.entity.PlaceCategory;
 import site.offload.offloadserver.db.place.entity.VisitedPlace;
 import site.offload.offloadserver.db.quest.entity.ProceedingQuest;
 import site.offload.offloadserver.db.quest.entity.Quest;
+import site.offload.offloadserver.db.quest.entity.QuestReward;
+import site.offload.offloadserver.db.quest.repository.QuestRepository;
 import site.offload.offloadserver.external.aws.S3UseCase;
 
 import java.util.ArrayList;
@@ -55,6 +59,8 @@ public class MemberUseCase {
     private final QuestService questService;
     private final ProceedingQuestService proceedingQuestService;
     private final S3UseCase s3UseCase;
+    private final QuestRewardService questRewardService;
+    private final CompleteQuestService completeQuestService;
 
     //단위 = meter
     private static final int RESTAURANT_CAFE_CULTURE_PERMIT_RADIUS = 25;
@@ -237,12 +243,13 @@ public class MemberUseCase {
 
                 //퀘스트 진행 내역이 없다면
             } else {
+                // TODO : 완료된 퀘스트인지 확인
                 proceedingQuest = proceedingQuestService.findById(createProceedingQuest(findMember, quest));
             }
 
             //퀘스트 필요 달성도와 진행도가 일치할 경우
             if (proceedingQuest.getCurrentClearCount() == quest.getTotalRequiredClearCount()) {
-                handleQuestComplete(proceedingQuest);
+                handleQuestComplete(findMember, proceedingQuest);
             }
         }
     }
@@ -268,7 +275,20 @@ public class MemberUseCase {
     }
 
     //TODO : 앱잼 이후 구현 필수
-    private void handleQuestComplete(final ProceedingQuest proceedingQuest) {
+    private void handleQuestComplete(final Member findMember, final ProceedingQuest proceedingQuest) {
+        Character character = characterService.findByName(findMember.getCurrentCharacterName());
+        Quest quest = proceedingQuest.getQuest();
+        QuestReward questReward = questRewardService.findByQuestId(quest.getId());
+
+        if (questReward.getRewardList().isCharacterMotion()){
+            CharacterMotion characterMotion = characterMotionService.findByCharacterAndPlaceCategory(character, quest.getPlaceCategory());
+            gainedCharacterMotionService.save(findMember, characterMotion);
+            // TODO : proceedingQuest에서 해당 퀘스트 지우고 CompleteQuest 테이블 만들고 추가
+            completeQuestService.saveCompleteQuest(quest, findMember);
+            proceedingQuestService.deleteProceedingQuest(quest, findMember);
+        }
+        else { // TODO : 엠블렘 또는 쿠폰일때
+        }
     }
 
 }

--- a/src/main/java/site/offload/offloadserver/api/quest/service/CompleteQuestService.java
+++ b/src/main/java/site/offload/offloadserver/api/quest/service/CompleteQuestService.java
@@ -1,0 +1,23 @@
+package site.offload.offloadserver.api.quest.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.offload.offloadserver.db.member.entity.Member;
+import site.offload.offloadserver.db.quest.entity.CompleteQuest;
+import site.offload.offloadserver.db.quest.entity.Quest;
+import site.offload.offloadserver.db.quest.repository.CompleteQuestRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CompleteQuestService {
+
+    private final CompleteQuestRepository completeQuestRepository;
+
+    public void saveCompleteQuest(Quest quest, Member member) {
+        completeQuestRepository.save(
+                CompleteQuest.builder()
+                .quest(quest)
+                .member(member)
+                .build());
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/quest/service/ProceedingQuestService.java
+++ b/src/main/java/site/offload/offloadserver/api/quest/service/ProceedingQuestService.java
@@ -42,4 +42,8 @@ public class ProceedingQuestService {
     public void updateCurrentClearCount(ProceedingQuest proceedingQuest, int count) {
         proceedingQuest.updateCurrentClearCount(count);
     }
+
+    public void deleteProceedingQuest(Quest quest, Member member){
+        proceedingQuestRepository.deleteByQuestAndMember(quest, member);
+    }
 }

--- a/src/main/java/site/offload/offloadserver/api/quest/service/QuestRewardService.java
+++ b/src/main/java/site/offload/offloadserver/api/quest/service/QuestRewardService.java
@@ -1,0 +1,17 @@
+package site.offload.offloadserver.api.quest.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.offload.offloadserver.db.quest.entity.QuestReward;
+import site.offload.offloadserver.db.quest.repository.QuestRewardRepository;
+
+@Service
+@RequiredArgsConstructor
+public class QuestRewardService {
+
+    private final QuestRewardRepository questRewardRepository;
+
+    public QuestReward findByQuestId(Integer questId) {
+        return questRewardRepository.findByQuestId(questId);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/charactermotion/entity/GainedCharacterMotion.java
+++ b/src/main/java/site/offload/offloadserver/db/charactermotion/entity/GainedCharacterMotion.java
@@ -2,6 +2,7 @@ package site.offload.offloadserver.db.charactermotion.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import site.offload.offloadserver.db.BaseTimeEntity;
 import site.offload.offloadserver.db.member.entity.Member;
@@ -24,4 +25,10 @@ public class GainedCharacterMotion extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "character_motion_id", nullable = false)
     private CharacterMotion characterMotion;
+
+    @Builder
+    public GainedCharacterMotion(Member member, CharacterMotion characterMotion){
+        this.member = member;
+        this.characterMotion = characterMotion;
+    }
 }

--- a/src/main/java/site/offload/offloadserver/db/quest/embeddable/RewardList.java
+++ b/src/main/java/site/offload/offloadserver/db/quest/embeddable/RewardList.java
@@ -9,11 +9,11 @@ import site.offload.offloadserver.db.emblem.entity.Emblem;
 public class RewardList {
 
     //캐릭터모션
-    private String characterMotionCode;
+    private boolean isCharacterMotion;
 
     //쿠폰 -> 앱잼 이후에 추가
     //private String couponCode;
 
     //칭호
-    private Emblem emblem;
+    private Emblem eblem;
 }

--- a/src/main/java/site/offload/offloadserver/db/quest/entity/CompleteQuest.java
+++ b/src/main/java/site/offload/offloadserver/db/quest/entity/CompleteQuest.java
@@ -1,0 +1,32 @@
+package site.offload.offloadserver.db.quest.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.offload.offloadserver.db.member.entity.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompleteQuest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "quest_id")
+    private Quest quest;
+
+    @Builder
+    private CompleteQuest(Member member, Quest quest) {
+        this.member = member;
+        this.quest = quest;
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/quest/entity/QuestReward.java
+++ b/src/main/java/site/offload/offloadserver/db/quest/entity/QuestReward.java
@@ -2,11 +2,13 @@ package site.offload.offloadserver.db.quest.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.offload.offloadserver.db.BaseTimeEntity;
 import site.offload.offloadserver.db.quest.embeddable.RewardList;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestReward extends BaseTimeEntity {
 

--- a/src/main/java/site/offload/offloadserver/db/quest/repository/CompleteQuestRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/quest/repository/CompleteQuestRepository.java
@@ -1,0 +1,11 @@
+package site.offload.offloadserver.db.quest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.offload.offloadserver.db.member.entity.Member;
+import site.offload.offloadserver.db.quest.entity.CompleteQuest;
+import site.offload.offloadserver.db.quest.entity.Quest;
+import site.offload.offloadserver.db.quest.entity.QuestReward;
+
+public interface CompleteQuestRepository extends JpaRepository<CompleteQuest, Long> {
+    void deleteByQuestAndMember(Quest quest, Member member);
+}

--- a/src/main/java/site/offload/offloadserver/db/quest/repository/ProceedingQuestRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/quest/repository/ProceedingQuestRepository.java
@@ -15,4 +15,6 @@ public interface ProceedingQuestRepository extends JpaRepository<ProceedingQuest
     Optional<ProceedingQuest> findByMemberAndQuest(Member member, Quest quest);
 
     boolean existsByMemberAndQuest(Member member, Quest quest);
+
+    void deleteByQuestAndMember(Quest quest, Member member);
 }

--- a/src/main/java/site/offload/offloadserver/db/quest/repository/QuestRewardRepository.java
+++ b/src/main/java/site/offload/offloadserver/db/quest/repository/QuestRewardRepository.java
@@ -1,7 +1,10 @@
 package site.offload.offloadserver.db.quest.repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.Repository;
 import site.offload.offloadserver.db.quest.entity.QuestReward;
 
-public interface QuestRewardRepository extends CrudRepository<QuestReward, Integer> {
+public interface QuestRewardRepository extends JpaRepository<QuestReward, Integer> {
+    QuestReward findByQuestId(Integer questId);
 }


### PR DESCRIPTION
## 변경사항

* 완료된 퀘스트를 저장하는 엔티티를 생성했습니다.

* 보상 모션을 찾아와 얻은 보상을 저장했습니다.

* 완료된 퀘스트에 퀘스트 추가, 진행중인 퀘스트에서 삭제를 구현했습니다.

## 고려사항

* 완료된 퀘스트인지 판단하고 그렇지 않아야 proceeding quest로 추가하는 작업이 필요합니다.

