### PR TITLE
[feat] 위치 정보 대조 API 생성

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/member/controller/MemberController.java
+++ b/src/main/java/site/offload/offloadserver/api/member/controller/MemberController.java
@@ -5,12 +5,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.offload.offloadserver.api.member.dto.request.AuthAdventureRequest;
+import site.offload.offloadserver.api.member.dto.request.AuthPositionRequest;
 import site.offload.offloadserver.api.member.dto.request.MemberAdventureInformationRequest;
 import site.offload.offloadserver.api.member.dto.request.MemberProfileUpdateRequest;
-import site.offload.offloadserver.api.member.dto.response.AuthAdventureResponse;
-import site.offload.offloadserver.api.member.dto.response.ChooseCharacterResponse;
-import site.offload.offloadserver.api.member.dto.response.MemberAdventureInformationResponse;
-import site.offload.offloadserver.api.member.dto.response.NicknameCheckResponse;
+import site.offload.offloadserver.api.member.dto.response.*;
 import site.offload.offloadserver.api.member.usecase.MemberUseCase;
 import site.offload.offloadserver.api.message.SuccessMessage;
 import site.offload.offloadserver.api.response.APISuccessResponse;
@@ -54,8 +52,14 @@ public class MemberController implements MemberControllerSwagger {
     }
 
     @PostMapping("/adventures/authentication")
-    public ResponseEntity<APISuccessResponse<AuthAdventureResponse>> authAdventure(final @RequestBody AuthAdventureRequest request) {
+    public ResponseEntity<APISuccessResponse<VerifyQrcodeResponse>> authAdventure(final @RequestBody AuthAdventureRequest request) {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.AUTHENTICATE_ADVENTURE_REQUEST_SUCCESS.getMessage(), memberUseCase.authAdventure(memberId, request));
+    }
+
+    @PostMapping("/places/distance")
+    public ResponseEntity<APISuccessResponse<VerifyPositionDistanceResponse>> authAdventureOnlyPlace(final @RequestBody AuthPositionRequest request) {
+        final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
+        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.AUTHENTICATE_ADVENTURE_REQUEST_SUCCESS.getMessage(), memberUseCase.authAdventurePosition(memberId, request));
     }
 }

--- a/src/main/java/site/offload/offloadserver/api/member/controller/MemberControllerSwagger.java
+++ b/src/main/java/site/offload/offloadserver/api/member/controller/MemberControllerSwagger.java
@@ -6,14 +6,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import site.offload.offloadserver.api.member.dto.request.AuthAdventureRequest;
+import site.offload.offloadserver.api.member.dto.request.AuthPositionRequest;
 import site.offload.offloadserver.api.member.dto.request.MemberProfileUpdateRequest;
-import site.offload.offloadserver.api.member.dto.response.AuthAdventureResponse;
-import site.offload.offloadserver.api.member.dto.response.ChooseCharacterResponse;
-import site.offload.offloadserver.api.member.dto.response.MemberAdventureInformationResponse;
-import site.offload.offloadserver.api.member.dto.response.NicknameCheckResponse;
+import site.offload.offloadserver.api.member.dto.response.*;
 import site.offload.offloadserver.api.response.APISuccessResponse;
 
 public interface MemberControllerSwagger {
@@ -48,8 +47,15 @@ public interface MemberControllerSwagger {
     @ApiResponse(responseCode = "200",
             description = "탐험 인증 성공",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    ResponseEntity<APISuccessResponse<AuthAdventureResponse>> authAdventure(final @RequestBody AuthAdventureRequest request);
+    ResponseEntity<APISuccessResponse<VerifyQrcodeResponse>> authAdventure(final @RequestBody AuthAdventureRequest request);
 
+
+
+    @Operation(summary = "위치 정보 탐험 인증 API", description = "QR코드로 탐험인증 하는 API")
+    @ApiResponse(responseCode = "200",
+            description = "탐험 인증 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    ResponseEntity<APISuccessResponse<VerifyPositionDistanceResponse>> authAdventureOnlyPlace(final @RequestBody AuthPositionRequest request);
 }
 
 

--- a/src/main/java/site/offload/offloadserver/api/member/dto/request/AuthPositionRequest.java
+++ b/src/main/java/site/offload/offloadserver/api/member/dto/request/AuthPositionRequest.java
@@ -1,0 +1,4 @@
+package site.offload.offloadserver.api.member.dto.request;
+
+public record AuthPositionRequest(Long placeId, double latitude, double longitude) {
+}

--- a/src/main/java/site/offload/offloadserver/api/member/dto/response/AuthAdventureResponse.java
+++ b/src/main/java/site/offload/offloadserver/api/member/dto/response/AuthAdventureResponse.java
@@ -1,8 +1,0 @@
-package site.offload.offloadserver.api.member.dto.response;
-
-public record AuthAdventureResponse(boolean isQRMatched) {
-
-    public static AuthAdventureResponse of(boolean isQRMatched) {
-        return new AuthAdventureResponse(isQRMatched);
-    }
-}

--- a/src/main/java/site/offload/offloadserver/api/member/dto/response/VerifyPositionDistanceResponse.java
+++ b/src/main/java/site/offload/offloadserver/api/member/dto/response/VerifyPositionDistanceResponse.java
@@ -1,0 +1,8 @@
+package site.offload.offloadserver.api.member.dto.response;
+
+public record VerifyPositionDistanceResponse(boolean isValidPosition, String successCharacterImageUrl) {
+
+    public static VerifyPositionDistanceResponse of(boolean isValidPosition, String characterImageUrl) {
+        return new VerifyPositionDistanceResponse(isValidPosition, characterImageUrl);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/api/member/dto/response/VerifyQrcodeResponse.java
+++ b/src/main/java/site/offload/offloadserver/api/member/dto/response/VerifyQrcodeResponse.java
@@ -1,0 +1,8 @@
+package site.offload.offloadserver.api.member.dto.response;
+
+public record VerifyQrcodeResponse(boolean isQRMatched, String characterImageUrl) {
+
+    public static VerifyQrcodeResponse of(boolean isQRMatched, String characterImageUrl) {
+        return new VerifyQrcodeResponse(isQRMatched, characterImageUrl);
+    }
+}

--- a/src/main/java/site/offload/offloadserver/db/character/entity/Character.java
+++ b/src/main/java/site/offload/offloadserver/db/character/entity/Character.java
@@ -29,6 +29,12 @@ public class Character extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String characterSpotLightImageUrl;
 
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String characterAdventureSuccessImageUrl;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String characterAdventureFailureImageUrl;
+
     @Column(nullable = false, unique = true)
     private String CharacterCode;
 }


### PR DESCRIPTION
## 변경사항
- 사용자 위치 정보 대조 API 생성 
## 고려사항
- 장소 카테고리에 따라 위치 정보만으로 인증을 하는 API, 위치 정보와 Qr코드로 인증을 하는 API를 나눠서 작성했습니다.
## Comment
- 관련 DTO 따로 나누고, MemberUseCase에서 로직을 추가했습니다. 
