### PR TITLE
[fix] 탐험정보 조회 모션이미지 기본이미지 둘다 반환

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/member/dto/response/MemberAdventureInformationResponse.java
+++ b/src/main/java/site/offload/offloadserver/api/member/dto/response/MemberAdventureInformationResponse.java
@@ -1,9 +1,20 @@
 package site.offload.offloadserver.api.member.dto.response;
 
-public record MemberAdventureInformationResponse(String nickname, String emblemName, String characterImgUrl,
+import lombok.Builder;
+
+@Builder
+public record MemberAdventureInformationResponse(String nickname, String emblemName, String baseImageUrl,
+                                                 String motionImageUrl,
                                                  String characterName) {
 
-    public static MemberAdventureInformationResponse of(final String nickname, final String emblemName, final String characterImgUrl, final String characterName) {
-        return new MemberAdventureInformationResponse(nickname, emblemName, characterImgUrl, characterName);
+    public static MemberAdventureInformationResponse of(final String nickname, final String emblemName,
+     final String baseImageUrl, final String motionImageUrl, final String characterName) {
+        return MemberAdventureInformationResponse.builder()
+                .nickname(nickname)
+                .emblemName(emblemName)
+                .characterName(characterName)
+                .baseImageUrl(baseImageUrl)
+                .motionImageUrl(motionImageUrl)
+                .build();
     }
 }

--- a/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
@@ -88,16 +88,17 @@ public class MemberUseCase {
         }
 
         final PlaceCategory placeCategory = PlaceCategory.valueOf(request.category().toUpperCase());
-        final String imageUrl = getMotionImageUrl(placeCategory, findCharacter, findMember);
-
-        return MemberAdventureInformationResponse.of(nickname, emblemName, s3UseCase.getPresignUrl(imageUrl), findCharacter.getName());
+        final String motionImageUrl = getMotionImageUrl(placeCategory, findCharacter, findMember);
+        final String baseImageUrl = findCharacter.getCharacterBaseImageUrl();
+        return MemberAdventureInformationResponse.of(nickname, emblemName,
+                s3UseCase.getPresignUrl(baseImageUrl), s3UseCase.getPresignUrl(motionImageUrl), findCharacter.getName());
     }
 
     private String getMotionImageUrl(final PlaceCategory placeCategory, final Character character, final Member member) {
 
-        // 카테고리가 없는 장소에 있을 경우 기본 이미지 url 반환
+        // 카테고리가 없는 장소에 있을 경우 null 반환
         if (placeCategory.equals(PlaceCategory.NONE)) {
-            return character.getCharacterBaseImageUrl();
+            return null;
         }
 
         // 그 외의 경우에는 특정 캐릭터, 특정 카테고리에 해당하는 모션 이미지 url 반환
@@ -106,9 +107,9 @@ public class MemberUseCase {
         //유저가 획득한 모션인지 확인
         if (isMemberGainedMotion(findCharacterMotion, member)) {
             return findCharacterMotion.getMotionImageUrl();
-            //아니라면 기본 이미지 반환
+            //아니라면 null 반환
         } else {
-            return character.getCharacterBaseImageUrl();
+            return null;
         }
     }
 

--- a/src/main/java/site/offload/offloadserver/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/site/offload/offloadserver/common/jwt/JwtTokenProvider.java
@@ -21,8 +21,10 @@ import java.util.concurrent.TimeUnit;
 public class JwtTokenProvider {
 
     private static final String MEMBER_ID = "memberId";
-    // ACCESS_TOKEN : 30분
-    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 30;
+
+    // TODO: access token 유효 기간
+    // ACCESS_TOKEN : 2일
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 2;
     // REFRESH_TOKEN : 7일
     private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 7;
 


### PR DESCRIPTION
## 변경사항
- 클라이언트  측 요청사항에 따라 access token의 유효 기간을 늘렸습니다. 
- 탐험 정보 조회 API에서 반환할 캐릭터 url을 기본 이미지 url과 로티 url 둘 다 포함시켰습니다.
- 그에 따라 서비스 로직을 수정하고 DTO 반환 값을 다시 설정했습니다.
## 고려사항
- 기본 이미지의 경우 항상 반환되지만 ,로티에 대한 url은 유저가 획득한 로티일 경우에만 반환하도록 했습니다.

