### PR TITLE
[chore] 탐험 실패 시 이미지 반환

### DIFF
--- a/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
+++ b/src/main/java/site/offload/offloadserver/api/member/usecase/MemberUseCase.java
@@ -162,7 +162,7 @@ public class MemberUseCase {
 
         // 클라이언트에서 받은 위도 경도 값을 카테고리 별 오차 범위 계산해서 PlaceId에 해당하는 장소의 위도 경도값과 비교
         if (!isValidLocation(request.latitude(), request.longitude(), findPlace.getLatitude(), findPlace.getLongitude(), findPlace.getPlaceCategory())) {
-            return VerifyPositionDistanceResponse.of(false, s3UseCase.getPresignUrl(findCharacter.getCharacterAdventureFailureImageUrl()));
+            return VerifyPositionDistanceResponse.of(false, s3UseCase.getPresignUrl(findCharacter.getCharacterAdventureLocationFailureImageUrl()));
         } else {
             authSucceedProcess(findMember, findPlace);
             return VerifyPositionDistanceResponse.of(true, s3UseCase.getPresignUrl(findCharacter.getCharacterAdventureSuccessImageUrl()));
@@ -196,7 +196,7 @@ public class MemberUseCase {
             authSucceedProcess(findMember, findPlace);
             return VerifyQrcodeResponse.of(true, s3UseCase.getPresignUrl(findCharacter.getCharacterAdventureSuccessImageUrl()));
         } else {
-            return VerifyQrcodeResponse.of(false, s3UseCase.getPresignUrl(findCharacter.getCharacterAdventureFailureImageUrl()));
+            return VerifyQrcodeResponse.of(false, s3UseCase.getPresignUrl(findCharacter.getCharacterAdventureQRFailureImageUrl()));
         }
     }
 

--- a/src/main/java/site/offload/offloadserver/db/character/entity/Character.java
+++ b/src/main/java/site/offload/offloadserver/db/character/entity/Character.java
@@ -33,7 +33,10 @@ public class Character extends BaseTimeEntity {
     private String characterAdventureSuccessImageUrl;
 
     @Column(nullable = false, columnDefinition = "TEXT")
-    private String characterAdventureFailureImageUrl;
+    private String characterAdventureQRFailureImageUrl;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String characterAdventureLocationFailureImageUrl;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String characterSelectImageUrl;


### PR DESCRIPTION
## 변경사항
- Character 필드에 탐험 인증 실패 시 반환할 이미지 경로 필드를 추가했습니다(QR코드 실패 시, 위치 정보 대조 실패 시)
## 고려사항
- 실패 시 이미지가 서로 다르므로, 필드를 추가하고 각 경우에 따라 다른 필드의 이미지 url을 반환하도록 했습니다.

