### PR TITLE
fix: Component Scan db module 추가

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/OffloadserverApiApplication.java
+++ b/offroad-api/src/main/java/site/offload/api/OffloadserverApiApplication.java
@@ -7,8 +7,15 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {"site.offload.api", "site.offload.common",
-        "site.offload.external", "site.offload.enums", "site.offload.cache", "site.offload.support"})
+@ComponentScan(basePackages = {
+        "site.offload.api",
+        "site.offload.common",
+        "site.offload.external",
+        "site.offload.enums",
+        "site.offload.cache",
+        "site.offload.support",
+        "site.offload.db"
+})
 @EnableJpaRepositories(basePackages = "site.offload.db")
 @EntityScan(basePackages = {"site.offload.db"})
 public class OffloadserverApiApplication {


### PR DESCRIPTION
## 변경사항
- ComponentScan 시에 db module을 포함하지 않아,  @JpaAuditingConfiguration을 Spring Bean으로 등록하지 못하는 문제를 해결했습니다.

## 고려사항

## Comment

## Test

## 질문사항

