### PR TITLE
fix: 닉네임, 캐릭터 선택 여부에 따른 모험 정보 조회 api 반환값 수정

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -74,8 +74,16 @@ public class MemberUseCase {
         final MemberEntity findMemberEntity = memberService.findById(request.memberId());
         final String nickname = findMemberEntity.getNickName();
         final String emblemName = findMemberEntity.getCurrentEmblemName();
-        final CharacterEntity findCharacterEntity = characterService.findByName(findMemberEntity.getCurrentCharacterName());
 
+        if (findMemberEntity.getNickName() == null && findMemberEntity.getCurrentCharacterName() == null) {
+            return MemberAdventureInformationResponse.of(null, emblemName, null, null, null);
+        }
+
+        if (findMemberEntity.getNickName() != null && findMemberEntity.getCurrentCharacterName() == null) {
+            return MemberAdventureInformationResponse.of(findMemberEntity.getNickName(), emblemName, null, null, null);
+        }
+
+        final CharacterEntity findCharacterEntity = characterService.findByName(findMemberEntity.getCurrentCharacterName());
         // 사용자가 획득한 캐릭터인지 확인
         if (!gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(findMemberEntity, findCharacterEntity)) {
             throw new BadRequestException(ErrorMessage.NOT_GAINED_CHARACTER);


### PR DESCRIPTION
## 변경사항
- 모험 정보 조회 API의 getMemberAdventureInformation의 코드를 수정했습니다
## 고려사항
- 닉네임 입력, 캐릭터 선택 둘 다 안한 경우 / 닉네임 입력 했는데 캐릭터 선택 안 한 경우로 나눠서 반환 값을 수정했습니다
## Comment
## Test
- 로컬에서 로그인 직후, 닉네임 입력 후, 캐릭터 입력 후 각각 모험 정보 조회 API를 요청해서 반환 되는 값을 확인했습니다
## 질문사항

