### PR TITLE
[feat] : 유저가 보유한 캐릭터 목록 조회 API 구현 및 GOOGLE 소셜로그인 시 플랫폼 저장

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/character/service/GainedCharacterService.java
+++ b/offroad-api/src/main/java/site/offload/api/character/service/GainedCharacterService.java
@@ -7,6 +7,8 @@ import site.offload.db.character.entity.GainedCharacterEntity;
 import site.offload.db.character.repository.GainedCharacterRepository;
 import site.offload.db.member.entity.MemberEntity;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class GainedCharacterService {

--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
@@ -6,6 +6,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.offload.api.auth.PrincipalHandler;
 import site.offload.api.member.dto.request.*;
+import site.offload.api.member.dto.request.AuthAdventureRequest;
+import site.offload.api.member.dto.request.AuthPositionRequest;
+import site.offload.api.member.dto.request.MemberAdventureInformationRequest;
+import site.offload.api.member.dto.request.MemberProfileUpdateRequest;
 import site.offload.api.member.dto.response.*;
 import site.offload.api.member.usecase.MemberUseCase;
 import site.offload.api.member.usecase.SignOutUseCase;
@@ -66,5 +70,12 @@ public class MemberController implements MemberControllerSwagger {
     public ResponseEntity<APISuccessResponse<Void>> signOut(@RequestBody final SignOutRequest request) {
         signOutUseCase.execute(request);
         return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.SIGN_OUT_SUCCESS.getMessage(), null);
+    }
+
+    @GetMapping("/characters")
+    public ResponseEntity<APISuccessResponse<GainedCharactersResponse>> getGainedCharacters() {
+        final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
+        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_GAINED_CHARACTERS_SUCCESS.getMessage(), memberUseCase.getGainedCharacters(memberId));
+
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharacterResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharacterResponse.java
@@ -1,0 +1,11 @@
+package site.offload.api.member.dto.response;
+
+public record GainedCharacterResponse(
+        String characterName,
+        String characterThumbnailImageUrl,
+        String characterDescription
+) {
+    public static GainedCharacterResponse of(String characterName, String characterThumbnailImageUrl, String characterDescription) {
+        return new GainedCharacterResponse(characterName, characterThumbnailImageUrl, characterDescription);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharactersResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharactersResponse.java
@@ -1,0 +1,12 @@
+package site.offload.api.member.dto.response;
+
+import java.util.List;
+
+public record GainedCharactersResponse(
+        List<GainedCharacterResponse> isGainedCharacters,
+        List<GainedCharacterResponse> isNotGainedCharacters
+) {
+    public static GainedCharactersResponse of(List<GainedCharacterResponse> isGainedCharacters, List<GainedCharacterResponse> isNotGainedCharacters) {
+        return new GainedCharactersResponse(isGainedCharacters, isNotGainedCharacters);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -15,10 +15,7 @@ import site.offload.api.member.dto.request.AuthAdventureRequest;
 import site.offload.api.member.dto.request.AuthPositionRequest;
 import site.offload.api.member.dto.request.MemberAdventureInformationRequest;
 import site.offload.api.member.dto.request.MemberProfileUpdateRequest;
-import site.offload.api.member.dto.response.ChooseCharacterResponse;
-import site.offload.api.member.dto.response.MemberAdventureInformationResponse;
-import site.offload.api.member.dto.response.VerifyPositionDistanceResponse;
-import site.offload.api.member.dto.response.VerifyQrcodeResponse;
+import site.offload.api.member.dto.response.*;
 import site.offload.api.member.service.MemberService;
 import site.offload.api.place.service.PlaceService;
 import site.offload.api.place.service.VisitedPlaceService;
@@ -306,5 +303,20 @@ public class MemberUseCase {
         // TODO: 코드 구조 개선 및 다른 보상 획득 추가
     }
 
+    @Transactional(readOnly = true)
+    public GainedCharactersResponse getGainedCharacters(Long memberId) {
+        List<CharacterEntity> characterEntities = characterService.findAll();
+        List<GainedCharacterResponse> isGainedCharacters = new ArrayList<GainedCharacterResponse>();
+        List<GainedCharacterResponse> isNotGainedCharacters = new ArrayList<GainedCharacterResponse>();
+
+        for (CharacterEntity characterEntity : characterEntities) {
+            if (gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberService.findById(memberId), characterEntity)) {
+                isGainedCharacters.add(GainedCharacterResponse.of(characterEntity.getName(), characterEntity.getCharacterBaseImageUrl(), characterEntity.getDescription()));
+            } else {
+                isNotGainedCharacters.add(GainedCharacterResponse.of(characterEntity.getName(), characterEntity.getNotGainedCharacterThumbnailImageUrl(), characterEntity.getDescription()));
+            }
+        }
+        return GainedCharactersResponse.of(isGainedCharacters, isNotGainedCharacters);
+    }
 }
 

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -306,17 +306,17 @@ public class MemberUseCase {
     @Transactional(readOnly = true)
     public GainedCharactersResponse getGainedCharacters(Long memberId) {
         List<CharacterEntity> characterEntities = characterService.findAll();
-        List<GainedCharacterResponse> isGainedCharacters = new ArrayList<GainedCharacterResponse>();
-        List<GainedCharacterResponse> isNotGainedCharacters = new ArrayList<GainedCharacterResponse>();
+        List<GainedCharacterResponse> gainedCharacters = new ArrayList<GainedCharacterResponse>();
+        List<GainedCharacterResponse> notGainedCharacters = new ArrayList<GainedCharacterResponse>();
 
         for (CharacterEntity characterEntity : characterEntities) {
             if (gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberService.findById(memberId), characterEntity)) {
-                isGainedCharacters.add(GainedCharacterResponse.of(characterEntity.getName(), characterEntity.getCharacterBaseImageUrl(), characterEntity.getDescription()));
+                gainedCharacters.add(GainedCharacterResponse.of(characterEntity.getName(), characterEntity.getCharacterBaseImageUrl(), characterEntity.getDescription()));
             } else {
-                isNotGainedCharacters.add(GainedCharacterResponse.of(characterEntity.getName(), characterEntity.getNotGainedCharacterThumbnailImageUrl(), characterEntity.getDescription()));
+                notGainedCharacters.add(GainedCharacterResponse.of(characterEntity.getName(), characterEntity.getNotGainedCharacterThumbnailImageUrl(), characterEntity.getDescription()));
             }
         }
-        return GainedCharactersResponse.of(isGainedCharacters, isNotGainedCharacters);
+        return GainedCharactersResponse.of(gainedCharacters, notGainedCharacters);
     }
 }
 

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/SocialLoginUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/SocialLoginUseCase.java
@@ -48,6 +48,7 @@ public class SocialLoginUseCase {
                         .name(googleInfoResponse.name())
                         .email(googleInfoResponse.email())
                         .sub(googleInfoResponse.id())
+                        .socialPlatform(SocialPlatform.valueOf(socialLoginRequest.socialPlatform().toString()))
                         .build();
                 memberService.saveMember(memberEntity);
                 isAlreadyExist = false;

--- a/offroad-api/src/main/resources/application-local.yaml
+++ b/offroad-api/src/main/resources/application-local.yaml
@@ -5,7 +5,7 @@ spring:
       on-profile: local
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:tcp://localhost/~/testdb
+    url: jdbc:h2:tcp://localhost/~/offroad
     username: sa
     password:
   jpa:

--- a/offroad-api/src/test/java/site/offload/api/character/CharacterEntityFixtureCreator.java
+++ b/offroad-api/src/test/java/site/offload/api/character/CharacterEntityFixtureCreator.java
@@ -2,7 +2,7 @@ package site.offload.api.character;
 
 import site.offload.db.character.entity.CharacterEntity;
 
-public class CreateCharacter {
+public class CharacterEntityFixtureCreator {
     public static CharacterEntity createCharacterEntity(String name,
                                                         String characterCode,
                                                         String characterAdventureSuccessImageUrl,

--- a/offroad-api/src/test/java/site/offload/api/character/CreateCharacter.java
+++ b/offroad-api/src/test/java/site/offload/api/character/CreateCharacter.java
@@ -1,0 +1,29 @@
+package site.offload.api.character;
+
+import site.offload.db.character.entity.CharacterEntity;
+
+public class CreateCharacter {
+    public static CharacterEntity createCharacterEntity(String name,
+                                                        String characterCode,
+                                                        String characterAdventureSuccessImageUrl,
+                                                        String characterBaseImageUrl,
+                                                        String characterSelectImageUrl,
+                                                        String characterSpotLightImageUrl,
+                                                        String characterAdventureQRFailureImageUrl,
+                                                        String notGainedCharacterThumbnailImageUrl,
+                                                        String description,
+                                                        String characterAdventureLocationFailureImageUrl) {
+        return CharacterEntity.builder()
+                .name(name)
+                .characterCode(characterCode)
+                .characterAdventureSuccessImageUrl(characterAdventureSuccessImageUrl)
+                .characterBaseImageUrl(characterBaseImageUrl)
+                .characterSelectImageUrl(characterSelectImageUrl)
+                .characterSpotLightImageUrl(characterSpotLightImageUrl)
+                .characterAdventureQRFailureImageUrl(characterAdventureQRFailureImageUrl)
+                .notGainedCharacterThumbnailImageUrl(notGainedCharacterThumbnailImageUrl)
+                .description(description)
+                .characterAdventureLocationFailureImageUrl(characterAdventureLocationFailureImageUrl)
+                .build();
+    }
+}

--- a/offroad-api/src/test/java/site/offload/api/character/service/GainedCharacterServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/character/service/GainedCharacterServiceTest.java
@@ -1,0 +1,69 @@
+package site.offload.api.character.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.offload.api.member.dto.response.GainedCharacterResponse;
+import site.offload.db.character.entity.CharacterEntity;
+import site.offload.db.character.entity.GainedCharacterEntity;
+import site.offload.db.character.repository.CharacterRepository;
+import site.offload.db.character.repository.GainedCharacterRepository;
+import site.offload.db.member.entity.MemberEntity;
+import site.offload.db.member.repository.MemberRepository;
+import site.offload.enums.member.SocialPlatform;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static site.offload.api.character.CreateCharacter.createCharacterEntity;
+
+@ExtendWith(MockitoExtension.class)
+public class GainedCharacterServiceTest {
+
+    @InjectMocks
+    GainedCharacterService gainedCharacterService;
+
+    @Mock
+    GainedCharacterRepository gainedCharacterRepository;
+
+
+    @Test
+    @DisplayName("보유 캐릭터와 미보유 캐릭터를 구별할 수 있다.")
+    void distinctGainedCharacterAndNotGainedCharacter() {
+        //given
+
+        MemberEntity memberEntity = MemberEntity.builder().name("이름1").email("이메일1").sub("소셜아이디1").socialPlatform(SocialPlatform.GOOGLE).build();
+
+        CharacterEntity characterEntity1 = createCharacterEntity("이름1", "캐릭터 코드1",
+                "탐험 성공 이미지1", "기본 이미지1", "선택 이미지1",
+                "주목 이미지1", "QR 실패 이미지1", "미보유 썸네일 이미지1"
+                , "설명1", "위치 인증 실패 이미지1");
+
+        CharacterEntity characterEntity2 = createCharacterEntity("이름2", "캐릭터 코드2",
+                "탐험 성공 이미지2", "기본 이미지2", "선택 이미지2",
+                "주목 이미지2", "QR 실패 이미지2", "미보유 썸네일 이미지2"
+                , "설명2", "위치 인증 실패 이미지2");
+
+        BDDMockito.given(gainedCharacterRepository.existsByCharacterEntityAndMemberEntity(characterEntity1, memberEntity))
+                .willReturn(true);
+        BDDMockito.given(gainedCharacterRepository.existsByCharacterEntityAndMemberEntity(characterEntity2, memberEntity))
+                .willReturn(false);
+
+        //when
+
+        boolean isExistsGainedCharacter1 = gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity1);
+        boolean isExistsGainedCharacter2 = gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity2);
+
+        //then
+
+        Assertions.assertThat(isExistsGainedCharacter1).isEqualTo(true);
+        Assertions.assertThat(isExistsGainedCharacter2).isEqualTo(false);
+
+    }
+}

--- a/offroad-api/src/test/java/site/offload/api/character/service/GainedCharacterServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/character/service/GainedCharacterServiceTest.java
@@ -8,20 +8,13 @@ import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import site.offload.api.member.dto.response.GainedCharacterResponse;
 import site.offload.db.character.entity.CharacterEntity;
-import site.offload.db.character.entity.GainedCharacterEntity;
-import site.offload.db.character.repository.CharacterRepository;
 import site.offload.db.character.repository.GainedCharacterRepository;
 import site.offload.db.member.entity.MemberEntity;
-import site.offload.db.member.repository.MemberRepository;
 import site.offload.enums.member.SocialPlatform;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.mockito.ArgumentMatchers.any;
-import static site.offload.api.character.CreateCharacter.createCharacterEntity;
+import static site.offload.api.character.CharacterEntityFixtureCreator.createCharacterEntity;
 
 @ExtendWith(MockitoExtension.class)
 public class GainedCharacterServiceTest {

--- a/offroad-api/src/test/java/site/offload/api/character/usecase/GainedCharacterUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/character/usecase/GainedCharacterUseCaseTest.java
@@ -1,0 +1,78 @@
+package site.offload.api.character.usecase;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.offload.api.character.service.GainedCharacterService;
+import site.offload.api.member.dto.response.GainedCharacterResponse;
+import site.offload.db.character.entity.CharacterEntity;
+import site.offload.db.character.repository.GainedCharacterRepository;
+import site.offload.db.member.entity.MemberEntity;
+import site.offload.enums.member.SocialPlatform;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static site.offload.api.character.CreateCharacter.createCharacterEntity;
+
+@ExtendWith(MockitoExtension.class)
+public class GainedCharacterUseCaseTest {
+
+    @InjectMocks
+    GainedCharacterService gainedCharacterService;
+
+    @Mock
+    GainedCharacterRepository gainedCharacterRepository;
+
+    @Test
+    @DisplayName("보유 캐릭터와 미보유 캐릭터를 구별되게 저장할 수 있다")
+    void saveDistinctGainedCharacterAndNotGainedCharacter() {
+        //given
+        List<GainedCharacterResponse> isGainedCharacters = new ArrayList<GainedCharacterResponse>();
+        List<GainedCharacterResponse> isNotGainedCharacters = new ArrayList<GainedCharacterResponse>();
+
+        CharacterEntity characterEntity1 = createCharacterEntity("이름1", "캐릭터 코드1",
+                "탐험 성공 이미지1", "기본 이미지1", "선택 이미지1",
+                "주목 이미지1", "QR 실패 이미지1", "미보유 썸네일 이미지1"
+                , "설명1", "위치 인증 실패 이미지1");
+
+        CharacterEntity characterEntity2 = createCharacterEntity("이름2", "캐릭터 코드2",
+                "탐험 성공 이미지2", "기본 이미지2", "선택 이미지2",
+                "주목 이미지2", "QR 실패 이미지2", "미보유 썸네일 이미지2"
+                , "설명2", "위치 인증 실패 이미지2");
+
+        MemberEntity memberEntity = MemberEntity.builder().name("이름1").email("이메일1").sub("소셜아이디1").socialPlatform(SocialPlatform.GOOGLE).build();
+
+        BDDMockito.given(gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity1))
+                .willReturn(true);
+        BDDMockito.given(gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity2))
+                .willReturn(false);
+
+        //when
+
+        if (gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity1)){
+            isGainedCharacters.add(GainedCharacterResponse.of(characterEntity1.getName(), characterEntity1.getCharacterBaseImageUrl(), characterEntity1.getDescription()));
+        }
+        else{
+            isNotGainedCharacters.add(GainedCharacterResponse.of(characterEntity1.getName(), characterEntity1.getNotGainedCharacterThumbnailImageUrl(), characterEntity1.getDescription()));
+        }
+
+        if (gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity2)){
+            isGainedCharacters.add(GainedCharacterResponse.of(characterEntity2.getName(), characterEntity2.getCharacterBaseImageUrl(), characterEntity2.getDescription()));
+        }
+        else{
+            isNotGainedCharacters.add(GainedCharacterResponse.of(characterEntity2.getName(), characterEntity2.getNotGainedCharacterThumbnailImageUrl(), characterEntity2.getDescription()));
+        }
+
+        //then
+
+        Assertions.assertThat(isGainedCharacters).contains(GainedCharacterResponse.of("이름1", "기본 이미지1", "설명1"));
+        Assertions.assertThat(isNotGainedCharacters).contains(GainedCharacterResponse.of("이름2", "미보유 썸네일 이미지2", "설명2"));
+
+    }
+}

--- a/offroad-db/src/main/java/site/offload/db/character/entity/CharacterEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/character/entity/CharacterEntity.java
@@ -2,6 +2,7 @@ package site.offload.db.character.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.offload.db.BaseTimeEntity;
@@ -43,4 +44,21 @@ public class CharacterEntity extends BaseTimeEntity {
 
     @Column(nullable = false, unique = true)
     private String CharacterCode;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String notGainedCharacterThumbnailImageUrl;
+
+    @Builder
+    public CharacterEntity(String name, String description, String characterBaseImageUrl, String characterSpotLightImageUrl, String characterAdventureSuccessImageUrl, String characterAdventureQRFailureImageUrl, String characterAdventureLocationFailureImageUrl, String characterSelectImageUrl, String characterCode, String notGainedCharacterThumbnailImageUrl) {
+        this.name = name;
+        this.description = description;
+        this.characterBaseImageUrl = characterBaseImageUrl;
+        this.characterSpotLightImageUrl = characterSpotLightImageUrl;
+        this.characterAdventureSuccessImageUrl = characterAdventureSuccessImageUrl;
+        this.characterAdventureQRFailureImageUrl = characterAdventureQRFailureImageUrl;
+        this.characterAdventureLocationFailureImageUrl = characterAdventureLocationFailureImageUrl;
+        this.characterSelectImageUrl = characterSelectImageUrl;
+        this.CharacterCode = characterCode;
+        this.notGainedCharacterThumbnailImageUrl = notGainedCharacterThumbnailImageUrl;
+    }
 }

--- a/offroad-db/src/main/java/site/offload/db/character/repository/GainedCharacterRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/character/repository/GainedCharacterRepository.java
@@ -6,6 +6,9 @@ import site.offload.db.character.entity.CharacterEntity;
 import site.offload.db.character.entity.GainedCharacterEntity;
 import site.offload.db.member.entity.MemberEntity;
 
+import java.lang.reflect.Member;
+import java.util.List;
+
 public interface GainedCharacterRepository extends JpaRepository<GainedCharacterEntity, Long> {
 
     boolean existsByCharacterEntityAndMemberEntity(CharacterEntity characterEntity, MemberEntity memberEntity);

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -21,6 +21,7 @@ public enum SuccessMessage {
     GET_GAINED_EMBLEM_SUCCESS("칭호 조회 완료"),
     GET_CHARACTERS_LIST_SUCCESS("캐릭터 목록 조회 완료"),
     GET_QUEST_INFORMATION_SUCCESS("퀘스트 정보 조회 성공"),
-    AUTHENTICATE_ADVENTURE_REQUEST_SUCCESS("탐험 인증 요청 성공");
+    AUTHENTICATE_ADVENTURE_REQUEST_SUCCESS("탐험 인증 요청 성공"),
+    GET_GAINED_CHARACTERS_SUCCESS("캐릭터 조회 성공");
     private final String message;
 }

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -22,6 +22,7 @@ public enum SuccessMessage {
     GET_CHARACTERS_LIST_SUCCESS("캐릭터 목록 조회 완료"),
     GET_QUEST_INFORMATION_SUCCESS("퀘스트 정보 조회 성공"),
     AUTHENTICATE_ADVENTURE_REQUEST_SUCCESS("탐험 인증 요청 성공"),
+
     GET_GAINED_CHARACTERS_SUCCESS("캐릭터 조회 성공");
     private final String message;
 }


### PR DESCRIPTION
## 변경사항

### 보유 캐릭터 및 미보유 캐릭터 조회

https://github.com/Team-Offroad/Offroad-server/blob/bbc2bf8cd731c73f5905de668078b06387d0cfa8/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java#L306-L319

* 모든 캐릭터를 가져온 후, 하나씩 조회해가며 보유한 캐릭터와 그렇지 않은 캐릭터를 구분했습니다.
* 보유 캐릭터인 경우 기본 이미지 URL, 미보유 캐릭터인 경우 썸네일 이미지 URL을 담아 보내도록 했습니다.

### yaml 파일에서 h2 database 이름 offroad로 수정

https://github.com/Team-Offroad/Offroad-server/blob/bbc2bf8cd731c73f5905de668078b06387d0cfa8/offroad-api/src/main/resources/application-local.yaml#L8

### GOOGLE 소셜로그인 시 플랫폼 저장

https://github.com/Team-Offroad/Offroad-server/blob/bbc2bf8cd731c73f5905de668078b06387d0cfa8/offroad-api/src/main/java/site/offload/api/member/usecase/SocialLoginUseCase.java#L51


## 고려사항

### Test

https://github.com/Team-Offroad/Offroad-server/blob/bbc2bf8cd731c73f5905de668078b06387d0cfa8/offroad-db/src/main/java/site/offload/db/character/entity/CharacterEntity.java#L51-L63

* Test를 위해서 CharacterEntity에 Builder 패턴을 추가하였습니다.

### Package

* Response DTO와 Usecase는 Member와 관련 있다고 생각해서(마이페이지 내 보유 및 미보유 캐릭터) Member 패키지에 두었고 Service와  Character와 관련있기 때문에 Character 패키지에 두었습니다.

## Test

<img width="728" alt="image" src="https://github.com/user-attachments/assets/7deea798-5ba4-41cc-b1a5-4b4350cecec8">

<img width="315" alt="image" src="https://github.com/user-attachments/assets/3edeafe6-4a5b-4d61-899b-4e1149458b13">



