### PR TITLE
[feat] : 칭호 목록 조회 API

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/OffloadserverApiApplication.java
+++ b/offroad-api/src/main/java/site/offload/api/OffloadserverApiApplication.java
@@ -3,7 +3,9 @@ package site.offload.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
@@ -13,9 +15,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
         "site.offload.external",
         "site.offload.enums",
         "site.offload.cache",
-        "site.offload.support",
         "site.offload.db"
-})
+}, excludeFilters = {@ComponentScan.Filter(
+        type = FilterType.CUSTOM,
+        classes = {TypeExcludeFilter.class}
+)})
 @EnableJpaRepositories(basePackages = "site.offload.db")
 @EntityScan(basePackages = {"site.offload.db"})
 public class OffloadserverApiApplication {

--- a/offroad-api/src/main/java/site/offload/api/auth/jwt/JwtTokenProvider.java
+++ b/offroad-api/src/main/java/site/offload/api/auth/jwt/JwtTokenProvider.java
@@ -23,8 +23,8 @@ public class JwtTokenProvider {
     private static final String MEMBER_ID = "memberId";
 
     // TODO: access token 유효 기간
-    // ACCESS_TOKEN : 2일
-    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 2;
+    // ACCESS_TOKEN : 10분
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 1000L * 60 * 10;
     // REFRESH_TOKEN : 7일
     private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 7;
 

--- a/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemController.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemController.java
@@ -30,7 +30,7 @@ public class EmblemController implements EmblemControllerSwagger {
     @GetMapping("/users/emblems")
     public ResponseEntity<APISuccessResponse<GainedEmblemListResponse>> getGainedEmblem() {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
-        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_GAINED_EMBLEM_SUCCESS.getMessage(),
+        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_GAINED_EMBLEMS_SUCCESS.getMessage(),
                 emblemUseCase.getGainedEmblems(memberId));
     }
 

--- a/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemController.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.offload.api.auth.PrincipalHandler;
 import site.offload.api.emblem.dto.request.UpdateCurrentEmblemRequest;
+import site.offload.api.emblem.dto.response.EmblemsResponse;
 import site.offload.api.emblem.dto.response.GainedEmblemListResponse;
 import site.offload.api.emblem.usecase.EmblemUseCase;
 import site.offload.api.response.APISuccessResponse;
@@ -13,12 +14,12 @@ import site.offload.enums.response.SuccessMessage;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users/emblems")
+@RequestMapping("/api")
 public class EmblemController implements EmblemControllerSwagger {
 
     private final EmblemUseCase emblemUseCase;
 
-    @PatchMapping
+    @PatchMapping("/users/emblems")
     public ResponseEntity<APISuccessResponse<Void>> updateEmblem(@RequestParam(value = "emblemCode") final String emblemCode) {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         emblemUseCase.updateCurrentEmblem(UpdateCurrentEmblemRequest.of(emblemCode, memberId));
@@ -26,10 +27,17 @@ public class EmblemController implements EmblemControllerSwagger {
                 SuccessMessage.MEMBER_CURRENT_EMBLEM_UPDATE_SUCCESS.getMessage(), null);
     }
 
-    @GetMapping
+    @GetMapping("/users/emblems")
     public ResponseEntity<APISuccessResponse<GainedEmblemListResponse>> getGainedEmblem() {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_GAINED_EMBLEM_SUCCESS.getMessage(),
                 emblemUseCase.getGainedEmblems(memberId));
+    }
+
+    @GetMapping("/emblems")
+    public ResponseEntity<APISuccessResponse<EmblemsResponse>> getEmblems() {
+        final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
+        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_EMBLEMS_SUCCESS.getMessage(),
+                emblemUseCase.getEmblems(memberId));
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/emblem/dto/response/EmblemResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/dto/response/EmblemResponse.java
@@ -1,0 +1,10 @@
+package site.offload.api.emblem.dto.response;
+
+public record EmblemResponse(
+        String emblemName,
+        String clearConditionQuestName
+) {
+    public static EmblemResponse of(String emblemName, String clearConditionQuestName) {
+        return new EmblemResponse(emblemName, clearConditionQuestName);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/emblem/dto/response/EmblemsResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/dto/response/EmblemsResponse.java
@@ -1,0 +1,12 @@
+package site.offload.api.emblem.dto.response;
+
+import java.util.List;
+
+public record EmblemsResponse(
+        List<EmblemResponse> gainedEmblems,
+        List<EmblemResponse> notGainedEmblems
+) {
+    public static EmblemsResponse of(List<EmblemResponse> gainedEmblems, List<EmblemResponse> notGainedEmblems){
+        return new EmblemsResponse(gainedEmblems, notGainedEmblems);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/emblem/usecase/EmblemUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/usecase/EmblemUseCase.java
@@ -4,15 +4,23 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.offload.api.emblem.dto.request.UpdateCurrentEmblemRequest;
+import site.offload.api.emblem.dto.response.EmblemResponse;
+import site.offload.api.emblem.dto.response.EmblemsResponse;
 import site.offload.api.emblem.dto.response.GainedEmblemListResponse;
 import site.offload.api.emblem.dto.response.GainedEmblemResponse;
 import site.offload.api.emblem.service.GainedEmblemService;
 import site.offload.api.exception.BadRequestException;
 import site.offload.api.exception.NotFoundException;
 import site.offload.api.member.service.MemberService;
+import site.offload.api.quest.service.QuestRewardService;
+import site.offload.api.quest.service.QuestService;
+import site.offload.db.emblem.entity.GainedEmblemEntity;
 import site.offload.db.member.entity.MemberEntity;
+import site.offload.db.quest.entity.QuestRewardEntity;
 import site.offload.enums.emblem.Emblem;
 import site.offload.enums.response.ErrorMessage;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +28,8 @@ public class EmblemUseCase {
 
     private final MemberService memberService;
     private final GainedEmblemService gainedEmblemService;
+    private final QuestRewardService questRewardService;
+    private final QuestService questService;
 
     @Transactional
     public void updateCurrentEmblem(final UpdateCurrentEmblemRequest request) {
@@ -46,5 +56,27 @@ public class EmblemUseCase {
         return GainedEmblemListResponse.of(gainedEmblemService.findAllByMemberId(memberId).stream().map(
                 gainedEmblem -> GainedEmblemResponse.of(gainedEmblem.getEmblemCode(),
                         Emblem.getEmblemByCode(gainedEmblem.getEmblemCode()).getEmblemName())).toList());
+    }
+
+    @Transactional(readOnly = true)
+    public EmblemsResponse getEmblems(Long memberId) {
+        List<QuestRewardEntity> questRewardEntitiesWithEmblems = questRewardService.findQuestWithEmblems();
+        List<GainedEmblemEntity> gainedEmblemEntities = gainedEmblemService.findAllByMemberId(memberId);
+
+        List<String> emblemCodes = gainedEmblemEntities.stream()
+                .map(GainedEmblemEntity::getEmblemCode)
+                .toList();
+
+        List<EmblemResponse> gainedEmblems = questRewardEntitiesWithEmblems.stream()
+                .filter(questRewardEntityWithEmblem -> emblemCodes.contains(questRewardEntityWithEmblem.getRewardList().getEmblemCode()))
+                .map(questRewardEntity -> EmblemResponse.of(Emblem.getEmblemByCode(questRewardEntity.getRewardList().getEmblemCode()).getEmblemName(), questService.findById(questRewardEntity.getQuestId()).getName()))
+                .toList();
+
+        List<EmblemResponse> notGainedEmblems = questRewardEntitiesWithEmblems.stream()
+                .filter(questRewardEntityWithEmblem -> !emblemCodes.contains(questRewardEntityWithEmblem.getRewardList().getEmblemCode()))
+                .map(questRewardEntity -> EmblemResponse.of(Emblem.getEmblemByCode(questRewardEntity.getRewardList().getEmblemCode()).getEmblemName(), questService.findById(questRewardEntity.getQuestId()).getName()))
+                .toList();
+
+        return EmblemsResponse.of(gainedEmblems, notGainedEmblems);
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -129,12 +129,12 @@ public class MemberUseCase {
 
         List<GainedCharacterResponse> gainedCharacters = characterEntities.stream()
                 .filter(characterEntity -> gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity))
-                .map(characterEntity -> GainedCharacterResponse.of(characterEntity.getName(), characterEntity.getCharacterBaseImageUrl(), characterEntity.getDescription()))
+                .map(characterEntity -> GainedCharacterResponse.of(characterEntity.getName(), s3Service.getPresignUrl(characterEntity.getCharacterBaseImageUrl()), characterEntity.getDescription()))
                 .collect(Collectors.toList());
 
         List<GainedCharacterResponse> notGainedCharacters = characterEntities.stream()
                 .filter(characterEntity -> !gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity))
-                .map(characterEntity -> GainedCharacterResponse.of(characterEntity.getName(), characterEntity.getNotGainedCharacterThumbnailImageUrl(), characterEntity.getDescription()))
+                .map(characterEntity -> GainedCharacterResponse.of(characterEntity.getName(), s3Service.getPresignUrl(characterEntity.getNotGainedCharacterThumbnailImageUrl()), characterEntity.getDescription()))
                 .collect(Collectors.toList());
 
         return GainedCharactersResponse.of(gainedCharacters, notGainedCharacters);

--- a/offroad-api/src/main/java/site/offload/api/quest/service/QuestRewardService.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/service/QuestRewardService.java
@@ -3,9 +3,12 @@ package site.offload.api.quest.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.offload.api.exception.NotFoundException;
+import site.offload.db.quest.entity.QuestEntity;
 import site.offload.db.quest.entity.QuestRewardEntity;
 import site.offload.db.quest.repository.QuestRewardRepository;
 import site.offload.enums.response.ErrorMessage;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +23,9 @@ public class QuestRewardService {
 
     public boolean isExistByQuestId(Integer questId) {
         return questRewardRepository.existsByQuestId(questId);
+    }
+
+    public List<QuestRewardEntity> findQuestWithEmblems() {
+        return questRewardRepository.findAllWithEmblems();
     }
 }

--- a/offroad-api/src/test/java/site/offload/api/questReward/repository/QuestRewardRepositoryTest.java
+++ b/offroad-api/src/test/java/site/offload/api/questReward/repository/QuestRewardRepositoryTest.java
@@ -1,0 +1,70 @@
+package site.offload.api.questReward.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import site.offload.db.quest.embeddable.RewardList;
+import site.offload.db.quest.entity.QuestRewardEntity;
+import site.offload.db.quest.repository.QuestRewardRepository;
+
+import java.util.List;
+
+@SpringBootTest
+public class QuestRewardRepositoryTest {
+
+    @Autowired
+    QuestRewardRepository questRewardRepository;
+
+    @Test
+    @DisplayName("보상이 칭호인 퀘스트 보상 엔티티를 불러올 수 있다.")
+    void findQuestRewardEntitiesWithEmblems() {
+
+        //given
+
+        QuestRewardEntity questRewardEntity1 = createQuestRewardEntity(1, createRewardList(false, null, "emblemCode1"));
+        QuestRewardEntity questRewardEntity2 = createQuestRewardEntity(2, createRewardList(false, "couponCode2", null));
+        QuestRewardEntity questRewardEntity3 = createQuestRewardEntity(3, createRewardList(false, "couponCode3", null));
+        QuestRewardEntity questRewardEntity4 = createQuestRewardEntity(4, createRewardList(false, null, "emblemCode4"));
+        QuestRewardEntity questRewardEntity5 = createQuestRewardEntity(5, createRewardList(false, null, "emblemCode5"));
+
+
+        questRewardRepository.save(questRewardEntity1);
+        questRewardRepository.save(questRewardEntity2);
+        questRewardRepository.save(questRewardEntity3);
+        questRewardRepository.save(questRewardEntity4);
+        questRewardRepository.save(questRewardEntity5);
+
+
+        //when
+        List<QuestRewardEntity> questRewardEntities = questRewardRepository.findAllWithEmblems();
+        List<String> emblems = questRewardEntities.stream()
+                .map(questRewardEntity -> questRewardEntity.getRewardList().getEmblemCode())
+                .toList();
+
+        //then
+
+        System.out.println("emblems = " + emblems);
+        Assertions.assertThat(emblems).contains(questRewardEntity1.getRewardList().getEmblemCode());
+        Assertions.assertThat(emblems).contains(questRewardEntity4.getRewardList().getEmblemCode());
+        Assertions.assertThat(emblems.size()).isEqualTo(3);
+
+
+        //이게 잘 동작되지 않는 이유는 저장과 찾을 때의 Entity가 서로 다르기 때문인가요?
+        // -> 쿼리문으로 실제 DB에서 찾아오기 때문에 영속성 Context에서 불러오지 않음. 즉, 새로운 다른 객체를 불러오는 것 같음
+        //Assertions.assertThat(questRewardEntities).contains(questRewardEntity1);
+        //Assertions.assertThat(questRewardEntities).contains(questRewardEntity4);
+    }
+
+    RewardList createRewardList(boolean isCharacterMotion, String couponCode, String emblemCode) {
+        return new RewardList(isCharacterMotion, couponCode, emblemCode);
+    }
+
+    QuestRewardEntity createQuestRewardEntity(int questId, RewardList rewardList) {
+        return QuestRewardEntity.builder()
+                .questId(questId)
+                .rewardList(rewardList)
+                .build();
+    }
+}

--- a/offroad-api/src/test/java/site/offload/api/questReward/repository/QuestRewardRepositoryTest.java
+++ b/offroad-api/src/test/java/site/offload/api/questReward/repository/QuestRewardRepositoryTest.java
@@ -1,46 +1,27 @@
 package site.offload.api.questReward.repository;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
-import site.offload.api.auth.jwt.JwtTokenProvider;
-import site.offload.api.member.usecase.SocialLoginUseCase;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
+import site.offload.db.config.JpaAuditingConfig;
 import site.offload.db.quest.embeddable.RewardList;
 import site.offload.db.quest.entity.QuestRewardEntity;
 import site.offload.db.quest.repository.QuestRewardRepository;
-import site.offload.external.oauth.apple.AppleSocialLoginService;
-import site.offload.external.oauth.google.GoogleSocialLoginService;
 
 import java.util.List;
 
 @DataJpaTest
+@Import(JpaAuditingConfig.class)
 public class QuestRewardRepositoryTest {
 
     @Autowired
     QuestRewardRepository questRewardRepository;
 
-    @MockBean
-    ObjectMapper objectMapper;
-
-    @MockBean
-    GoogleSocialLoginService googleSocialLoginService;
-
-    @MockBean
-    AppleSocialLoginService appleSocialLoginService;
-
-
     @Test
-    @Transactional
     @DisplayName("보상이 칭호인 퀘스트 보상 엔티티를 불러올 수 있다.")
     void findQuestRewardEntitiesWithEmblems() {
 

--- a/offroad-api/src/test/java/site/offload/api/questReward/repository/QuestRewardRepositoryTest.java
+++ b/offroad-api/src/test/java/site/offload/api/questReward/repository/QuestRewardRepositoryTest.java
@@ -1,23 +1,46 @@
 package site.offload.api.questReward.repository;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import site.offload.api.auth.jwt.JwtTokenProvider;
+import site.offload.api.member.usecase.SocialLoginUseCase;
 import site.offload.db.quest.embeddable.RewardList;
 import site.offload.db.quest.entity.QuestRewardEntity;
 import site.offload.db.quest.repository.QuestRewardRepository;
+import site.offload.external.oauth.apple.AppleSocialLoginService;
+import site.offload.external.oauth.google.GoogleSocialLoginService;
 
 import java.util.List;
 
-@SpringBootTest
+@DataJpaTest
 public class QuestRewardRepositoryTest {
 
     @Autowired
     QuestRewardRepository questRewardRepository;
 
+    @MockBean
+    ObjectMapper objectMapper;
+
+    @MockBean
+    GoogleSocialLoginService googleSocialLoginService;
+
+    @MockBean
+    AppleSocialLoginService appleSocialLoginService;
+
+
     @Test
+    @Transactional
     @DisplayName("보상이 칭호인 퀘스트 보상 엔티티를 불러올 수 있다.")
     void findQuestRewardEntitiesWithEmblems() {
 
@@ -53,8 +76,8 @@ public class QuestRewardRepositoryTest {
 
         //이게 잘 동작되지 않는 이유는 저장과 찾을 때의 Entity가 서로 다르기 때문인가요?
         // -> 쿼리문으로 실제 DB에서 찾아오기 때문에 영속성 Context에서 불러오지 않음. 즉, 새로운 다른 객체를 불러오는 것 같음
-        //Assertions.assertThat(questRewardEntities).contains(questRewardEntity1);
-        //Assertions.assertThat(questRewardEntities).contains(questRewardEntity4);
+        Assertions.assertThat(questRewardEntities).contains(questRewardEntity1);
+        Assertions.assertThat(questRewardEntities).contains(questRewardEntity4);
     }
 
     RewardList createRewardList(boolean isCharacterMotion, String couponCode, String emblemCode) {

--- a/offroad-api/src/test/java/site/offload/api/questReward/service/QuestRewardServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/questReward/service/QuestRewardServiceTest.java
@@ -1,0 +1,65 @@
+package site.offload.api.questReward.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.offload.api.quest.service.QuestRewardService;
+import site.offload.db.quest.embeddable.RewardList;
+import site.offload.db.quest.entity.QuestRewardEntity;
+import site.offload.db.quest.repository.QuestRewardRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@ExtendWith(MockitoExtension.class)
+public class QuestRewardServiceTest {
+
+    @InjectMocks
+    QuestRewardService questRewardService;
+
+    @Mock
+    QuestRewardRepository questRewardRepository;
+
+    @Test
+    @DisplayName("보상이 칭호인 퀘스트 보상 엔티티들을 반환할 수 있다.")
+    void findQuestRewardEntitiesWithEmblems() {
+
+        //given
+
+        QuestRewardEntity questRewardEntity1 = createQuestRewardEntity(1, createRewardList(false, null, "emblemCode1"));
+        QuestRewardEntity questRewardEntity4 = createQuestRewardEntity(4, createRewardList(false, null, "emblemCode4"));
+
+        List<QuestRewardEntity> questRewardEntitiesWithEmblems = new ArrayList<QuestRewardEntity>();
+        questRewardEntitiesWithEmblems.add(questRewardEntity1);
+        questRewardEntitiesWithEmblems.add(questRewardEntity4);
+
+        BDDMockito.given(questRewardRepository.findAllWithEmblems())
+                .willReturn(questRewardEntitiesWithEmblems);
+
+        //when
+
+        List<QuestRewardEntity> expect = questRewardService.findQuestWithEmblems();
+
+        //then
+
+        Assertions.assertThat(expect).isEqualTo(questRewardEntitiesWithEmblems);
+
+    }
+
+    RewardList createRewardList(boolean isCharacterMotion, String couponCode, String emblemCode) {
+        return new RewardList(isCharacterMotion, couponCode, emblemCode);
+    }
+
+    QuestRewardEntity createQuestRewardEntity(int questId, RewardList rewardList){
+        return QuestRewardEntity.builder()
+                .questId(questId)
+                .rewardList(rewardList)
+                .build();
+    }
+}

--- a/offroad-api/src/test/java/site/offload/api/questReward/usecase/QuestRewardUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/questReward/usecase/QuestRewardUseCaseTest.java
@@ -1,0 +1,96 @@
+package site.offload.api.questReward.usecase;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.offload.api.character.service.GainedCharacterService;
+import site.offload.api.emblem.dto.response.EmblemResponse;
+import site.offload.api.emblem.dto.response.EmblemsResponse;
+import site.offload.api.emblem.service.GainedEmblemService;
+import site.offload.api.emblem.usecase.EmblemUseCase;
+import site.offload.api.quest.service.QuestRewardService;
+import site.offload.api.quest.service.QuestService;
+import site.offload.db.emblem.entity.GainedEmblemEntity;
+import site.offload.db.member.entity.MemberEntity;
+import site.offload.db.quest.embeddable.RewardList;
+import site.offload.db.quest.entity.QuestRewardEntity;
+import site.offload.enums.emblem.Emblem;
+import site.offload.enums.member.SocialPlatform;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class QuestRewardUseCaseTest {
+
+    @Mock
+    QuestRewardService questRewardService;
+
+    @Mock
+    GainedEmblemService gainedEmblemService;
+
+
+
+    @Test
+    @DisplayName("보유 및 미보유 엠블렘을 구별할 수 있다.")
+    void distinctGainedAndNotGainedEmblems(){
+
+        //given
+
+        MemberEntity memberEntity = MemberEntity.builder().name("이름1").email("이메일1").sub("소셜아이디1").socialPlatform(SocialPlatform.GOOGLE).build();
+
+        QuestRewardEntity questRewardEntity1 = createQuestRewardEntity(1, createRewardList(false, null, "emblemCode1"));
+        QuestRewardEntity questRewardEntity2 = createQuestRewardEntity(2, createRewardList(false, null, "emblemCode2"));
+        QuestRewardEntity questRewardEntity3 = createQuestRewardEntity(3, createRewardList(false, null, "emblemCode3"));
+
+        List<QuestRewardEntity> questRewardEntitiesWithEmblems = new ArrayList<QuestRewardEntity>();
+
+        questRewardEntitiesWithEmblems.add(questRewardEntity1);
+        questRewardEntitiesWithEmblems.add(questRewardEntity2);
+        questRewardEntitiesWithEmblems.add(questRewardEntity3);
+
+        List<GainedEmblemEntity> gainedEmblemEntities = new ArrayList<GainedEmblemEntity>();
+        gainedEmblemEntities.add(GainedEmblemEntity.create(memberEntity, "emblemCode1"));
+
+        //when
+
+        List<String> emblemCodes = gainedEmblemEntities.stream()
+                .map(GainedEmblemEntity::getEmblemCode)
+                .toList();
+
+        List<String> gainedEmblems = questRewardEntitiesWithEmblems.stream()
+                .filter(questRewardEntityWithEmblem -> emblemCodes.contains(questRewardEntityWithEmblem.getRewardList().getEmblemCode()))
+                .map(questRewardEntity -> questRewardEntity.getRewardList().getEmblemCode())
+                .toList();
+
+        List<String> notGainedEmblems = questRewardEntitiesWithEmblems.stream()
+                .filter(questRewardEntityWithEmblem -> !emblemCodes.contains(questRewardEntityWithEmblem.getRewardList().getEmblemCode()))
+                .map(questRewardEntity -> questRewardEntity.getRewardList().getEmblemCode())
+                .toList();
+
+        //then
+        Assertions.assertThat(gainedEmblems).contains(questRewardEntity1.getRewardList().getEmblemCode());
+        Assertions.assertThat(notGainedEmblems).contains(questRewardEntity2.getRewardList().getEmblemCode());
+        Assertions.assertThat(notGainedEmblems).contains(questRewardEntity3.getRewardList().getEmblemCode());
+
+    }
+
+    RewardList createRewardList(boolean isCharacterMotion, String couponCode, String emblemCode) {
+        return new RewardList(isCharacterMotion, couponCode, emblemCode);
+    }
+
+    QuestRewardEntity createQuestRewardEntity(int questId, RewardList rewardList){
+        return QuestRewardEntity.builder()
+                .questId(questId)
+                .rewardList(rewardList)
+                .build();
+    }
+}

--- a/offroad-db/src/main/java/site/offload/db/quest/entity/QuestRewardEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/quest/entity/QuestRewardEntity.java
@@ -2,6 +2,7 @@ package site.offload.db.quest.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.offload.db.BaseTimeEntity;
@@ -22,4 +23,11 @@ public class QuestRewardEntity extends BaseTimeEntity {
 
     @Embedded
     private RewardList rewardList;
+
+    @Builder
+    public QuestRewardEntity(Integer id, int questId, RewardList rewardList) {
+        this.id = id;
+        this.questId = questId;
+        this.rewardList = rewardList;
+    }
 }

--- a/offroad-db/src/main/java/site/offload/db/quest/repository/QuestRewardRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/quest/repository/QuestRewardRepository.java
@@ -2,12 +2,18 @@ package site.offload.db.quest.repository;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import site.offload.db.quest.entity.QuestRewardEntity;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface QuestRewardRepository extends JpaRepository<QuestRewardEntity, Integer> {
     Optional<QuestRewardEntity> findByQuestId(Integer questId);
 
     boolean existsByQuestId(Integer questId);
+
+    //@Query("SELECT q FROM QuestRewardEntity q WHERE q.rewardList.emblemCode != null")
+    @Query("SELECT q FROM QuestRewardEntity q WHERE q.rewardList.emblemCode IS NOT NULL")
+    List<QuestRewardEntity> findAllWithEmblems();
 }

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -18,11 +18,12 @@ public enum SuccessMessage {
     CHECK_DUPLICATED_NICKNAME_SUCCESS("닉네임 중복 확인 완료"),
     MEMBER_CURRENT_EMBLEM_UPDATE_SUCCESS("칭호 변경 성공"),
     CHOOSE_CHARACTER_SUCCESS("캐릭터 선택 완료"),
-    GET_GAINED_EMBLEM_SUCCESS("칭호 조회 완료"),
+    GET_GAINED_EMBLEM_SUCCESS("보유 칭호 조회 완료"),
     GET_CHARACTERS_LIST_SUCCESS("캐릭터 목록 조회 완료"),
     GET_QUEST_INFORMATION_SUCCESS("퀘스트 정보 조회 성공"),
     AUTHENTICATE_ADVENTURE_REQUEST_SUCCESS("탐험 인증 요청 성공"),
     GET_GAINED_CHARACTERS_SUCCESS("캐릭터 조회 성공"),
-    GET_COUPON_LIST_SUCCESS("획득 쿠폰 조회 요청 성공");
+    GET_COUPON_LIST_SUCCESS("획득 쿠폰 조회 요청 성공"),
+    GET_EMBLEMS_SUCCESS("칭호 조회 완료");
     private final String message;
 }

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -18,7 +18,7 @@ public enum SuccessMessage {
     CHECK_DUPLICATED_NICKNAME_SUCCESS("닉네임 중복 확인 완료"),
     MEMBER_CURRENT_EMBLEM_UPDATE_SUCCESS("칭호 변경 성공"),
     CHOOSE_CHARACTER_SUCCESS("캐릭터 선택 완료"),
-    GET_GAINED_EMBLEM_SUCCESS("보유 칭호 조회 완료"),
+    GET_GAINED_EMBLEMS_SUCCESS("보유 칭호 목록 조회 완료"),
     GET_CHARACTERS_LIST_SUCCESS("캐릭터 목록 조회 완료"),
     GET_QUEST_INFORMATION_SUCCESS("퀘스트 정보 조회 성공"),
     AUTHENTICATE_ADVENTURE_REQUEST_SUCCESS("탐험 인증 요청 성공"),


### PR DESCRIPTION
## 변경사항

### 칭호 목록 조회 API 

https://github.com/Team-Offroad/Offroad-server/blob/42e931c83908823f2af2d4a9e72c8c336c5f6cda/offroad-api/src/main/java/site/offload/api/emblem/usecase/EmblemUseCase.java#L62-L80

* 우선 퀘스트 보상으로 칭호를 가지는 퀘스트 리워드 엔티티들을 불러옵니다.

* 이후 내가 보유한 엠블렘 엔티티들을 불러오고 엠블렘 코드들을 모았습니다.

* 퀘스트 보상으로 칭호를 가지는 퀘스트 리워드 엔티티들을 비교하며 엠블렘 코드가 내가 가지고 있는 코드라면 보유, 아니면 미보유로 분류합니다. 퀘스트 이름은 questService의 메소드를 사용해서 불러왔습니다. 

## 고려사항

* User가 보유하거나 보유하지 않은 칭호 목록을 조회하기 때문에 /users/emblems로 url을 설정하려고 했으나 이미 존재할 뿐더러, 결국 emblem이라는 자원을 조회하는 것이라 생각해서 URL을 /emblems로 설정했습니다. 

## Comment

## Test

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/f51f130a-1bcf-423f-a35f-21dc5816365f/b2b559e0-7511-4881-8a71-12c71b94a24a/Untitled.png)

<img width="278" alt="image" src="https://github.com/user-attachments/assets/4f55a156-3a52-48d8-83b7-8b539ce4d5fb">


## 질문사항

https://github.com/Team-Offroad/Offroad-server/blob/42e931c83908823f2af2d4a9e72c8c336c5f6cda/offroad-api/src/test/java/site/offload/api/questReward/repository/QuestRewardRepositoryTest.java#L54-L58

* 이 API의 핵심 중 하나는 Repository에서 쿼리문을 이용하여 보상이 칭호인 엔티티들을 제대로 불러오는지의 여부라고 생각해서 이를 테스트해보기로 했습니다. Mockito 대신 SpringBootTest를 이용해서 테스트를 하던 중 Respository에 저장한 엔티티와 불러온 엔티티가 달라서 실패하게 되었습니다. 하지만 그 내용은 똑같았기에 내용을 비교하는 테스트에서는 통과할 수 있었습니다. 저는 이 이유를 @Query문을 통해 DB에서 직접 내용은 동일하지만 저장할 때와 다른 다른 Entity를 통해 가져왔기에 실패했다고 생각하고 있는데 정확한 이유가 궁금합니다..!!