### PR TITLE
[feat] : 캐릭터 선택시 상세 정보 조회 API 구현 및 swagger 작성

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/character/controller/CharacterController.java
+++ b/offroad-api/src/main/java/site/offload/api/character/controller/CharacterController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import site.offload.api.character.dto.response.CharacterDetailResponse;
 import site.offload.api.character.dto.response.CharacterListResponse;
 import site.offload.api.character.usecase.CharacterUseCase;
 import site.offload.api.response.APISuccessResponse;
@@ -23,5 +25,13 @@ public class CharacterController implements CharacterControllerSwagger {
     public ResponseEntity<APISuccessResponse<CharacterListResponse>> getCharacters() {
         return APISuccessResponse.of(HttpStatus.OK.value(),
                 SuccessMessage.GET_CHARACTERS_LIST_SUCCESS.getMessage(), characterUseCase.getCharacters());
+    }
+
+    @GetMapping("/{characterId}")
+    public ResponseEntity<APISuccessResponse<CharacterDetailResponse>> getCharacterDetail(
+            @PathVariable(value = "characterId") Integer characterId
+    ) {
+        return APISuccessResponse.of(HttpStatus.OK.value(),
+                SuccessMessage.GET_CHARACTER_DETAIL_SUCCESS.getMessage(), characterUseCase.getCharacterDetail(characterId));
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/character/controller/CharacterControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/character/controller/CharacterControllerSwagger.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import site.offload.api.character.dto.response.CharacterDetailResponse;
 import site.offload.api.character.dto.response.CharacterListResponse;
 import site.offload.api.response.APISuccessResponse;
 
@@ -15,4 +16,10 @@ public interface CharacterControllerSwagger {
             description = "캐릭터 목록 조회 성공",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
     ResponseEntity<APISuccessResponse<CharacterListResponse>> getCharacters();
+
+    @Operation(summary = "캐릭터 상세 목록 조회 API", description = "캐릭터 상세 목록 조회 API")
+    @ApiResponse(responseCode = "200",
+            description = "캐릭터 상세 목록 조회 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    ResponseEntity<APISuccessResponse<CharacterDetailResponse>> getCharacterDetail(Integer characterId);
 }

--- a/offroad-api/src/main/java/site/offload/api/character/dto/response/CharacterDetailResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/character/dto/response/CharacterDetailResponse.java
@@ -1,5 +1,8 @@
 package site.offload.api.character.dto.response;
 
+import lombok.Builder;
+
+@Builder
 public record CharacterDetailResponse(
         Integer characterId,
         String characterName,
@@ -8,9 +11,18 @@ public record CharacterDetailResponse(
         String characterDescription,
         String characterSummaryDescription,
         String characterMainColorCode,
-        String CharacterSubColorCode
+        String characterSubColorCode
 ) {
     public static CharacterDetailResponse of(Integer characterId, String characterName, String characterBaseImageUrl, String characterIconImageUrl, String characterDescription, String characterSummaryDescription, String characterMainColorCode, String characterSubColorCode) {
-        return new CharacterDetailResponse(characterId, characterName, characterBaseImageUrl, characterIconImageUrl, characterDescription, characterSummaryDescription, characterMainColorCode, characterSubColorCode);
+        return CharacterDetailResponse.builder()
+                .characterId(characterId)
+                .characterName(characterName)
+                .characterBaseImageUrl(characterBaseImageUrl)
+                .characterIconImageUrl(characterIconImageUrl)
+                .characterDescription(characterDescription)
+                .characterSummaryDescription(characterSummaryDescription)
+                .characterMainColorCode(characterMainColorCode)
+                .characterSubColorCode(characterSubColorCode)
+                .build();
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/character/dto/response/CharacterDetailResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/character/dto/response/CharacterDetailResponse.java
@@ -1,0 +1,16 @@
+package site.offload.api.character.dto.response;
+
+public record CharacterDetailResponse(
+        Integer characterId,
+        String characterName,
+        String characterBaseImageUrl,
+        String characterIconImageUrl,
+        String characterDescription,
+        String characterSummaryDescription,
+        String characterMainColorCode,
+        String CharacterSubColorCode
+) {
+    public static CharacterDetailResponse of(Integer characterId, String characterName, String characterBaseImageUrl, String characterIconImageUrl, String characterDescription, String characterSummaryDescription, String characterMainColorCode, String characterSubColorCode) {
+        return new CharacterDetailResponse(characterId, characterName, characterBaseImageUrl, characterIconImageUrl, characterDescription, characterSummaryDescription, characterMainColorCode, characterSubColorCode);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/character/usecase/CharacterUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/character/usecase/CharacterUseCase.java
@@ -3,6 +3,7 @@ package site.offload.api.character.usecase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.offload.api.character.dto.response.CharacterDetailResponse;
 import site.offload.api.character.dto.response.CharacterListResponse;
 import site.offload.api.character.dto.response.CharacterResponse;
 import site.offload.api.character.service.CharacterService;
@@ -31,5 +32,11 @@ public class CharacterUseCase {
                         .build()
         ).toList();
         return CharacterListResponse.of(charactersList);
+    }
+
+    @Transactional(readOnly = true)
+    public CharacterDetailResponse getCharacterDetail(Integer characterId) {
+        CharacterEntity characterEntity = characterService.findById(characterId);
+        return CharacterDetailResponse.of(characterId, characterEntity.getName(), s3Service.getPresignUrl(characterEntity.getCharacterBaseImageUrl()), s3Service.getPresignUrl(characterEntity.getCharacterIconImageUrl()), characterEntity.getDescription(), characterEntity.getSummaryDescription(), characterEntity.getCharacterMainColorCode(), characterEntity.getCharacterSubColorCode());
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/charactermotion/controller/CharacterMotionController.java
+++ b/offroad-api/src/main/java/site/offload/api/charactermotion/controller/CharacterMotionController.java
@@ -16,14 +16,14 @@ import site.offload.enums.response.SuccessMessage;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-public class CharacterMotionController {
+public class CharacterMotionController implements CharacterMotionControllerSwagger {
 
     private final CharacterMotionUseCase characterMotionUseCase;
 
     @GetMapping("/motions/{characterId}")
     public ResponseEntity<APISuccessResponse<CharacterMotionsResponse>> getMotions(
             @PathVariable(value = "characterId") Integer characterId
-    ){
+    ) {
         Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_MOTIONS_SUCCESS.getMessage(), characterMotionUseCase.getMotions(memberId, characterId));
     }

--- a/offroad-api/src/main/java/site/offload/api/charactermotion/controller/CharacterMotionControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/charactermotion/controller/CharacterMotionControllerSwagger.java
@@ -1,0 +1,19 @@
+package site.offload.api.charactermotion.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import site.offload.api.character.dto.response.CharacterDetailResponse;
+import site.offload.api.charactermotion.dto.CharacterMotionsResponse;
+import site.offload.api.response.APISuccessResponse;
+
+public interface CharacterMotionControllerSwagger {
+
+    @Operation(summary = "캐릭터 모션 목록 조회 API", description = "캐릭터 모션 목록 조회 API")
+    @ApiResponse(responseCode = "200",
+            description = "캐릭터 모션 목록 조회 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    public ResponseEntity<APISuccessResponse<CharacterMotionsResponse>> getMotions(Integer characterId);
+}

--- a/offroad-api/src/main/java/site/offload/api/coupon/controller/CouponControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/controller/CouponControllerSwagger.java
@@ -4,13 +4,24 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import site.offload.api.auth.PrincipalHandler;
+import site.offload.api.coupon.dto.CouponApplyRequest;
+import site.offload.api.coupon.dto.CouponApplyResponse;
 import site.offload.api.coupon.dto.CouponListResponse;
 import site.offload.api.response.APISuccessResponse;
+import site.offload.enums.response.SuccessMessage;
 
 public interface CouponControllerSwagger {
 
     @Operation(summary = "획득 쿠폰 목록 조회 API", description = "사용한 쿠폰, 사용된 쿠폰 반환하는 API")
     @ApiResponse(responseCode = "200", description = "획득 쿠폰 조회 요청 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
     ResponseEntity<APISuccessResponse<CouponListResponse>> getCouponList();
+
+    @Operation(summary = "쿠폰 적용 API", description = "쿠폰 적용 API")
+    @ApiResponse(responseCode = "200", description = "쿠폰 적용 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    public ResponseEntity<APISuccessResponse<CouponApplyResponse>> useCoupon(CouponApplyRequest request);
 }

--- a/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemControllerSwagger.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
+import site.offload.api.emblem.dto.response.EmblemsResponse;
 import site.offload.api.emblem.dto.response.GainedEmblemListResponse;
 import site.offload.api.response.APISuccessResponse;
 
@@ -22,4 +23,10 @@ public interface EmblemControllerSwagger {
             description = "칭호 조회 완료",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
     ResponseEntity<APISuccessResponse<GainedEmblemListResponse>> getGainedEmblem();
+
+    @Operation(summary = "칭호 조회 API", description = "칭호 목록을 조회하는 API 입니다.")
+    @ApiResponse(responseCode = "200",
+            description = "칭호 조회 완료",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    public ResponseEntity<APISuccessResponse<EmblemsResponse>> getEmblems();
 }

--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
@@ -47,6 +47,9 @@ public interface MemberControllerSwagger {
     @ApiResponse(responseCode = "200", description = "로그아웃 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
     ResponseEntity<APISuccessResponse<Void>> signOut(@RequestBody final SignOutRequest request);
 
+    @Operation(summary = "캐릭터 목록 조회 API", description = "캐릭터 목록 조회 API")
+    @ApiResponse(responseCode = "200", description = "캐릭터 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    public ResponseEntity<APISuccessResponse<GainedCharactersResponse>> getGainedCharacters();
 }
 
 

--- a/offroad-api/src/test/java/site/offload/api/character/service/CharacterServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/character/service/CharacterServiceTest.java
@@ -1,0 +1,45 @@
+package site.offload.api.character.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import site.offload.api.exception.NotFoundException;
+import site.offload.db.character.entity.CharacterEntity;
+import site.offload.db.character.repository.CharacterRepository;
+import site.offload.enums.response.ErrorMessage;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static site.offload.api.fixture.CharacterEntityFixtureCreator.createCharacterEntity;
+
+@ExtendWith(MockitoExtension.class)
+public class CharacterServiceTest {
+
+    @InjectMocks
+    CharacterService characterService;
+
+    @Mock
+    CharacterRepository characterRepository;
+
+    @Test
+    @DisplayName("캐릭터 ID에 해당하는 캐릭터 엔티티를 조회할 수 있다.")
+    void getCharacterEntityByCharacterId() {
+        //given
+        CharacterEntity characterEntity = createCharacterEntity("이름", "캐릭터 코드",
+                "탐험 성공 이미지", "기본 이미지", "선택 이미지",
+                "주목 이미지", "QR 실패 이미지", "미보유 썸네일 이미지"
+                , "설명", "위치 인증 실패 이미지", "캐릭터 메인 색깔 코드", "캐릭터 서브 색깔 코드", "캐릭터 요약 설명", "캐릭터 아이콘 이미지");
+        BDDMockito.given(characterRepository.findById(1)).willReturn(Optional.ofNullable(characterEntity));
+        //when
+        CharacterEntity expectedCharacterEntity = characterService.findById(1);
+        //then
+        Assertions.assertThat(expectedCharacterEntity).isEqualTo(characterEntity);
+    }
+}

--- a/offroad-api/src/test/java/site/offload/api/character/service/GainedCharacterServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/character/service/GainedCharacterServiceTest.java
@@ -13,6 +13,7 @@ import site.offload.db.character.repository.GainedCharacterRepository;
 import site.offload.db.member.entity.MemberEntity;
 import site.offload.enums.member.SocialPlatform;
 
+import static org.mockito.ArgumentMatchers.any;
 import static site.offload.api.fixture.CharacterEntityFixtureCreator.createCharacterEntity;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,12 +36,12 @@ public class GainedCharacterServiceTest {
         CharacterEntity characterEntity1 = createCharacterEntity("이름1", "캐릭터 코드1",
                 "탐험 성공 이미지1", "기본 이미지1", "선택 이미지1",
                 "주목 이미지1", "QR 실패 이미지1", "미보유 썸네일 이미지1"
-                , "설명1", "위치 인증 실패 이미지1", "캐릭터 메인 색깔 코드", "캐릭터 서브 색깔 코드");
+                , "설명1", "위치 인증 실패 이미지1", "캐릭터 메인 색깔 코드1", "캐릭터 서브 색깔 코드1", "캐릭터 요약 설명1", "캐릭터 아이콘 이미지1");
 
         CharacterEntity characterEntity2 = createCharacterEntity("이름2", "캐릭터 코드2",
                 "탐험 성공 이미지2", "기본 이미지2", "선택 이미지2",
                 "주목 이미지2", "QR 실패 이미지2", "미보유 썸네일 이미지2"
-                , "설명2", "위치 인증 실패 이미지2", "캐릭터 메인 색깔 코드", "캐릭터 서브 색깔 코드");
+                , "설명2", "위치 인증 실패 이미지2", "캐릭터 메인 색깔 코드2", "캐릭터 서브 색깔 코드2", "캐릭터 요약 설명2", "캐릭터 아이콘 이미지2");
 
         BDDMockito.given(gainedCharacterRepository.existsByCharacterEntityAndMemberEntity(characterEntity1, memberEntity))
                 .willReturn(true);

--- a/offroad-api/src/test/java/site/offload/api/character/usecase/GainedCharacterUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/character/usecase/GainedCharacterUseCaseTest.java
@@ -38,12 +38,12 @@ public class GainedCharacterUseCaseTest {
         CharacterEntity characterEntity1 = createCharacterEntity("이름1", "캐릭터 코드1",
                 "탐험 성공 이미지1", "기본 이미지1", "선택 이미지1",
                 "주목 이미지1", "QR 실패 이미지1", "미보유 썸네일 이미지1"
-                , "설명1", "위치 인증 실패 이미지1", "캐릭터 메인 색깔 코드1", "캐릭터 서브 색깔 코드1");
+                , "설명1", "위치 인증 실패 이미지1", "캐릭터 메인 색깔 코드1", "캐릭터 서브 색깔 코드1", "캐릭터 요약 설명1", "캐릭터 아이콘 이미지1");
 
         CharacterEntity characterEntity2 = createCharacterEntity("이름2", "캐릭터 코드2",
                 "탐험 성공 이미지2", "기본 이미지2", "선택 이미지2",
                 "주목 이미지2", "QR 실패 이미지2", "미보유 썸네일 이미지2"
-                , "설명2", "위치 인증 실패 이미지2", "캐릭터 메인 색깔 코드2", "캐릭터 서브 색깔 코드2");
+                , "설명2", "위치 인증 실패 이미지2", "캐릭터 메인 색깔 코드2", "캐릭터 서브 색깔 코드2", "캐릭터 요약 설명2", "캐릭터 아이콘 이미지2");
 
         MemberEntity memberEntity = MemberEntity.builder().name("이름1").email("이메일1").sub("소셜아이디1").socialPlatform(SocialPlatform.GOOGLE).build();
 

--- a/offroad-api/src/test/java/site/offload/api/charactermotion/service/CharacterMotionServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/charactermotion/service/CharacterMotionServiceTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static site.offload.api.fixture.CharacterEntityFixtureCreator.createCharacterEntity;
+import static site.offload.api.fixture.CharacterMotionEntityFixtureCreator.createCharacterMotionEntity;
 
 @ExtendWith(MockitoExtension.class)
 public class CharacterMotionServiceTest {
@@ -36,12 +37,12 @@ public class CharacterMotionServiceTest {
         CharacterEntity characterEntity = createCharacterEntity("이름", "캐릭터 코드",
                 "탐험 성공 이미지", "기본 이미지", "선택 이미지",
                 "주목 이미지", "QR 실패 이미지", "미보유 썸네일 이미지"
-                , "설명", "위치 인증 실패 이미지", "캐릭터 메인 색깔 코드", "캐릭터 서브 색깔 코드");
+                , "설명", "위치 인증 실패 이미지", "캐릭터 메인 색깔 코드", "캐릭터 서브 색깔 코드", "캐릭터 요약 설명", "캐릭터 아이콘 이미지");
 
-        CharacterMotionEntity characterMotionEntity1 = createCharacterMotionEntity(characterEntity, PlaceCategory.CAFFE, "모션 이미지1", "미보유 이미지1");
-        CharacterMotionEntity characterMotionEntity2 = createCharacterMotionEntity(characterEntity, PlaceCategory.CULTURE, "모션 이미지2", "미보유 이미지2");
-        CharacterMotionEntity characterMotionEntity3 = createCharacterMotionEntity(characterEntity, PlaceCategory.RESTAURANT, "모션 이미지3", "미보유 이미지3");
-        CharacterMotionEntity characterMotionEntity4 = createCharacterMotionEntity(characterEntity, PlaceCategory.SPORT, "모션 이미지4", "미보유 이미지4");
+        CharacterMotionEntity characterMotionEntity1 = createCharacterMotionEntity(characterEntity, PlaceCategory.CAFFE, "모션 이미지1", "미보유 이미지1", "캡쳐 이미지1");
+        CharacterMotionEntity characterMotionEntity2 = createCharacterMotionEntity(characterEntity, PlaceCategory.CULTURE, "모션 이미지2", "미보유 이미지2", "캡쳐 이미지2");
+        CharacterMotionEntity characterMotionEntity3 = createCharacterMotionEntity(characterEntity, PlaceCategory.RESTAURANT, "모션 이미지3", "미보유 이미지3", "캡쳐 이미지3");
+        CharacterMotionEntity characterMotionEntity4 = createCharacterMotionEntity(characterEntity, PlaceCategory.SPORT, "모션 이미지4", "미보유 이미지4", "캡쳐 이미지4");
 
         List<CharacterMotionEntity> characterMotionEntities = new ArrayList<CharacterMotionEntity>();
         characterMotionEntities.add(characterMotionEntity1);
@@ -59,15 +60,6 @@ public class CharacterMotionServiceTest {
         //then
 
         Assertions.assertThat(expectedResult).isEqualTo(characterMotionEntities);
-    }
-
-    CharacterMotionEntity createCharacterMotionEntity(CharacterEntity characterEntity, PlaceCategory placeCategory, String motionImageUrl, String notGainedMotionThumbnailImageUrl) {
-        return CharacterMotionEntity.builder()
-                .characterEntity(characterEntity)
-                .placeCategory(placeCategory)
-                .motionImageUrl(motionImageUrl)
-                .notGainedMotionThumbnailImageUrl(notGainedMotionThumbnailImageUrl)
-                .build();
     }
 
 

--- a/offroad-api/src/test/java/site/offload/api/charactermotion/usecase/CharacterMotionUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/charactermotion/usecase/CharacterMotionUseCaseTest.java
@@ -58,7 +58,7 @@ public class CharacterMotionUseCaseTest {
         CharacterEntity characterEntity = createCharacterEntity("이름1", "캐릭터 코드1",
                 "탐험 성공 이미지1", "기본 이미지1", "선택 이미지1",
                 "주목 이미지1", "QR 실패 이미지1", "미보유 썸네일 이미지1"
-                , "설명1", "위치 인증 실패 이미지1", "캐릭터 메인 색깔 코드", "캐릭터 서브 색깔 코드");
+                , "설명1", "위치 인증 실패 이미지1", "캐릭터 메인 색깔 코드1", "캐릭터 서브 색깔 코드1", "캐릭터 요약 설명1", "캐릭터 아이콘 이미지1");
 
         CharacterMotionEntity characterMotionEntity1 = createCharacterMotionEntity(characterEntity, PlaceCategory.CAFFE, "모션 이미지1", "미보유 이미지1", "모션 캡쳐 이미지1");
         CharacterMotionEntity characterMotionEntity2 = createCharacterMotionEntity(characterEntity, PlaceCategory.CULTURE, "모션 이미지2", "미보유 이미지2", "모션 캡쳐 이미지2");

--- a/offroad-api/src/test/java/site/offload/api/fixture/CharacterEntityFixtureCreator.java
+++ b/offroad-api/src/test/java/site/offload/api/fixture/CharacterEntityFixtureCreator.java
@@ -14,7 +14,9 @@ public class CharacterEntityFixtureCreator {
                                                         String description,
                                                         String characterAdventureLocationFailureImageUrl,
                                                         String characterMainColorCode,
-                                                        String characterSubColorCode) {
+                                                        String characterSubColorCode,
+                                                        String summaryDescription,
+                                                        String characterIconImageUrl) {
         return CharacterEntity.builder()
                 .name(name)
                 .characterCode(characterCode)
@@ -28,6 +30,8 @@ public class CharacterEntityFixtureCreator {
                 .characterAdventureLocationFailureImageUrl(characterAdventureLocationFailureImageUrl)
                 .characterMainColorCode(characterMainColorCode)
                 .characterSubColorCode(characterSubColorCode)
+                .characterIconImageUrl(characterIconImageUrl)
+                .summaryDescription(summaryDescription)
                 .build();
     }
 }

--- a/offroad-api/src/test/java/site/offload/api/member/usecase/AuthAdventureUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/member/usecase/AuthAdventureUseCaseTest.java
@@ -110,7 +110,9 @@ class AuthAdventureUseCaseTest {
                 "characterDescription",
                 "characterAdventureLocationFailureImageUrl",
                 "캐릭터 메인 색깔 코드",
-                "캐릭터 서브 색깔 코드"
+                "캐릭터 서브 색깔 코드",
+                "캐릭터 요약 설명",
+                "캐릭터 아이콘 이미지"
         );
 
         QuestEntity questEntity1 = createQuest(

--- a/offroad-db/src/main/java/site/offload/db/character/entity/CharacterEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/character/entity/CharacterEntity.java
@@ -22,6 +22,9 @@ public class CharacterEntity extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false)
+    private String summaryDescription;
+
     @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
 
@@ -49,6 +52,9 @@ public class CharacterEntity extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String notGainedCharacterThumbnailImageUrl;
 
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String characterIconImageUrl;
+
     private PlaceArea placeArea;
 
     @Column(nullable = false)
@@ -58,7 +64,7 @@ public class CharacterEntity extends BaseTimeEntity {
     private String characterSubColorCode;
 
     @Builder
-    public CharacterEntity(String name, String description, String characterBaseImageUrl, String characterSpotLightImageUrl, String characterAdventureSuccessImageUrl, String characterAdventureQRFailureImageUrl, String characterAdventureLocationFailureImageUrl, String characterSelectImageUrl, String characterCode, String notGainedCharacterThumbnailImageUrl, String characterMainColorCode, String characterSubColorCode) {
+    public CharacterEntity(String name, String description, String characterBaseImageUrl, String characterSpotLightImageUrl, String characterAdventureSuccessImageUrl, String characterAdventureQRFailureImageUrl, String characterAdventureLocationFailureImageUrl, String characterSelectImageUrl, String characterCode, String notGainedCharacterThumbnailImageUrl, String characterMainColorCode, String characterSubColorCode, String summaryDescription, String characterIconImageUrl) {
         this.name = name;
         this.description = description;
         this.characterBaseImageUrl = characterBaseImageUrl;
@@ -71,5 +77,7 @@ public class CharacterEntity extends BaseTimeEntity {
         this.notGainedCharacterThumbnailImageUrl = notGainedCharacterThumbnailImageUrl;
         this.characterMainColorCode = characterMainColorCode;
         this.characterSubColorCode = characterSubColorCode;
+        this.characterIconImageUrl = characterIconImageUrl;
+        this.summaryDescription = summaryDescription;
     }
 }

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -26,6 +26,7 @@ public enum SuccessMessage {
     GET_COUPON_LIST_SUCCESS("획득 쿠폰 조회 요청 성공"),
     GET_COUPON_APPLY_SUCCESS("획득 쿠폰 사용 요청 성공"),
     GET_EMBLEMS_SUCCESS("칭호 조회 완료"),
-    GET_MOTIONS_SUCCESS("캐릭터 모션 목록 조회 성공");
+    GET_MOTIONS_SUCCESS("캐릭터 모션 목록 조회 성공"),
+    GET_CHARACTER_DETAIL_SUCCESS("캐릭터 상세 정보 조회 성공");
     private final String message;
 }


### PR DESCRIPTION
## 변경사항

### 캐릭터 선택시 상세 정보 API

* 캐릭터를 선택하면 보여지는 정보를 응답하는 API를 작성했습니다.

### 누락된 swagger작성

* 누락된 swagger를 작성했습니다.

## Test
<img width="700" alt="image" src="https://github.com/user-attachments/assets/717c9126-aa0b-43f9-898c-702c067a1727">

<img width="264" alt="image" src="https://github.com/user-attachments/assets/9ab9dc9c-d1d3-4506-9507-7071611e8a2b">

