### PR TITLE
feat: 퀘스트 목록 조회 api 구현

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/quest/controller/QuestController.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/controller/QuestController.java
@@ -16,19 +16,19 @@ import site.offload.api.response.APISuccessResponse;
 import site.offload.enums.response.SuccessMessage;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class QuestController implements QuestControllerSwagger {
 
     private final QuestUseCase questUseCase;
 
-    @GetMapping("/quests")
+    @GetMapping("/users/quests")
     public ResponseEntity<APISuccessResponse<QuestResponse>> getQuestInformation() {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_QUEST_INFORMATION_SUCCESS.getMessage(), questUseCase.getQuestInformation(memberId));
     }
 
-    @GetMapping("/quests/detail")
+    @GetMapping("/quests")
     public ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam(value = "isActive") boolean isActive) {
         return APISuccessResponse.of(
                 HttpStatus.OK.value(),

--- a/offroad-api/src/main/java/site/offload/api/quest/controller/QuestController.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/controller/QuestController.java
@@ -5,8 +5,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.offload.api.auth.PrincipalHandler;
+import site.offload.api.quest.dto.request.QuestDetailListRequest;
+import site.offload.api.quest.dto.response.QuestDetailListResponse;
 import site.offload.api.quest.dto.response.QuestResponse;
 import site.offload.api.quest.usecase.QuestUseCase;
 import site.offload.api.response.APISuccessResponse;
@@ -25,4 +28,11 @@ public class QuestController implements QuestControllerSwagger {
         return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_QUEST_INFORMATION_SUCCESS.getMessage(), questUseCase.getQuestInformation(memberId));
     }
 
+    @GetMapping("/quests/detail")
+    public ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam(value = "isActive") boolean isActive) {
+        return APISuccessResponse.of(
+                HttpStatus.OK.value(),
+                SuccessMessage.GET_QUEST_DETAIL_LIST_SUCCESS.getMessage(),
+                questUseCase.getQuestDetailList(PrincipalHandler.getMemberIdFromPrincipal(), isActive));
+    }
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/controller/QuestControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/controller/QuestControllerSwagger.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+import site.offload.api.quest.dto.request.QuestDetailListRequest;
+import site.offload.api.quest.dto.response.QuestDetailListResponse;
 import site.offload.api.quest.dto.response.QuestResponse;
 import site.offload.api.response.APISuccessResponse;
 
@@ -15,4 +18,10 @@ public interface QuestControllerSwagger {
             description = "퀘스트 정보 조회 완료",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
     public ResponseEntity<APISuccessResponse<QuestResponse>> getQuestInformation();
+
+    @Operation(summary = "퀘스트 목록 조회 API", description = "퀘스트 목록 탭의 정보를 조회하는 API입니다.")
+    @ApiResponse(responseCode = "200",
+            description = "퀘스트 목록 정보 조회 완료",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    public ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam boolean isActive);
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/request/QuestDetailListRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/request/QuestDetailListRequest.java
@@ -1,0 +1,4 @@
+package site.offload.api.quest.dto.request;
+
+public record QuestDetailListRequest(boolean isActive) {
+}

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailListResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailListResponse.java
@@ -1,0 +1,9 @@
+package site.offload.api.quest.dto.response;
+
+import java.util.List;
+
+public record QuestDetailListResponse(List<QuestDetailResponse> questList) {
+    public static QuestDetailListResponse of(List<QuestDetailResponse> questList) {
+        return new QuestDetailListResponse(questList);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailResponse.java
@@ -1,0 +1,22 @@
+package site.offload.api.quest.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record QuestDetailResponse(String questName, String description,
+                                  int currentCount, int totalCount, String requirement,
+                                  String reward) {
+
+    public static QuestDetailResponse of(String questName, String description,
+                                         int currentCount, int totalCount, String requirement,
+                                         String reward) {
+        return QuestDetailResponse.builder()
+                .questName(questName)
+                .currentCount(currentCount)
+                .totalCount(totalCount)
+                .requirement(requirement)
+                .reward(reward)
+                .description(description)
+                .build();
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/quest/service/CompleteQuestService.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/service/CompleteQuestService.java
@@ -7,11 +7,17 @@ import site.offload.db.quest.entity.CompleteQuestEntity;
 import site.offload.db.quest.entity.QuestEntity;
 import site.offload.db.quest.repository.CompleteQuestRepository;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class CompleteQuestService {
 
     private final CompleteQuestRepository completeQuestRepository;
+
+    public List<CompleteQuestEntity> findAllByMemberId(Long id) {
+        return completeQuestRepository.findAllByMemberEntityId(id);
+    }
 
     public void saveCompleteQuest(QuestEntity questEntity, MemberEntity memberEntity) {
         completeQuestRepository.save(

--- a/offroad-api/src/main/java/site/offload/api/quest/service/ProceedingQuestService.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/service/ProceedingQuestService.java
@@ -9,6 +9,8 @@ import site.offload.db.quest.entity.QuestEntity;
 import site.offload.db.quest.repository.ProceedingQuestRepository;
 import site.offload.enums.response.ErrorMessage;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class ProceedingQuestService {
@@ -49,5 +51,9 @@ public class ProceedingQuestService {
 
     public void deleteAllByMemberId(long memberId) {
         proceedingQuestRepository.deleteAllByMemberEntityId(memberId);
+    }
+
+    public List<ProceedingQuestEntity> findAllByMemberId(long memberId) {
+        return proceedingQuestRepository.findAllByMemberEntityId(memberId);
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/service/QuestService.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/service/QuestService.java
@@ -20,6 +20,10 @@ public class QuestService {
     private final ProceedingQuestRepository proceedingQuestRepository;
     private final QuestRepository questRepository;
 
+    public List<QuestEntity> findByIdNotIn(List<Integer> questIds) {
+        return questRepository.findByIdNotIn(questIds);
+    }
+
     public List<ProceedingQuestEntity> findProceedingQuests(Long memberId) {
         return proceedingQuestRepository.findAllByMemberEntityIdOrderByUpdatedAtDesc(memberId);
     }

--- a/offroad-api/src/test/java/site/offload/api/fixture/CompleteQuestEntityFixture.java
+++ b/offroad-api/src/test/java/site/offload/api/fixture/CompleteQuestEntityFixture.java
@@ -1,0 +1,15 @@
+package site.offload.api.fixture;
+
+import site.offload.db.member.entity.MemberEntity;
+import site.offload.db.quest.entity.CompleteQuestEntity;
+import site.offload.db.quest.entity.QuestEntity;
+
+public class CompleteQuestEntityFixture {
+
+    public static CompleteQuestEntity createCompleteQuestEntity(MemberEntity memberEntity, QuestEntity questEntity) {
+        return CompleteQuestEntity.builder()
+                .questEntity(questEntity)
+                .memberEntity(memberEntity)
+                .build();
+    }
+}

--- a/offroad-api/src/test/java/site/offload/api/fixture/ProceedingQuestEntityFixture.java
+++ b/offroad-api/src/test/java/site/offload/api/fixture/ProceedingQuestEntityFixture.java
@@ -1,0 +1,12 @@
+package site.offload.api.fixture;
+
+import site.offload.db.member.entity.MemberEntity;
+import site.offload.db.quest.entity.ProceedingQuestEntity;
+import site.offload.db.quest.entity.QuestEntity;
+
+public class ProceedingQuestEntityFixture {
+
+    public static ProceedingQuestEntity createProceedingQuest(MemberEntity memberEntity, QuestEntity questEntity) {
+        return ProceedingQuestEntity.create(memberEntity, questEntity);
+    }
+}

--- a/offroad-api/src/test/java/site/offload/api/quest/service/CompleteQuestServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/quest/service/CompleteQuestServiceTest.java
@@ -1,0 +1,57 @@
+package site.offload.api.quest.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.offload.api.fixture.CompleteQuestEntityFixture;
+import site.offload.api.fixture.MemberEntityFixtureCreator;
+import site.offload.db.member.entity.MemberEntity;
+import site.offload.db.quest.entity.CompleteQuestEntity;
+import site.offload.db.quest.entity.QuestEntity;
+import site.offload.db.quest.repository.CompleteQuestRepository;
+import site.offload.enums.member.SocialPlatform;
+import site.offload.enums.place.PlaceArea;
+import site.offload.enums.place.PlaceCategory;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static site.offload.api.fixture.QuestEntityFixtureCreator.createQuest;
+
+@ExtendWith(MockitoExtension.class)
+
+public class CompleteQuestServiceTest {
+
+
+    @InjectMocks
+    private CompleteQuestService completeQuestService;
+
+    @Mock
+    private CompleteQuestRepository completeQuestRepository;
+
+    @Test
+    @DisplayName("멤버 id로 완료된 퀘스트를 모두 조호할 수 있다.")
+    void findAllByMemberId() {
+
+        //given
+        MemberEntity memberEntity1 = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
+        QuestEntity questEntity1 = createQuest(true, "test", PlaceCategory.NONE, PlaceArea.NONE, 1);
+        QuestEntity questEntity2 = createQuest(false, "test", PlaceCategory.CAFFE, PlaceArea.NONE, 2);
+        CompleteQuestEntity completeQuestEntity1 = CompleteQuestEntityFixture.createCompleteQuestEntity(memberEntity1, questEntity1);
+        CompleteQuestEntity completeQuestEntity2 = CompleteQuestEntityFixture.createCompleteQuestEntity(memberEntity1, questEntity2);
+
+        given(completeQuestRepository.findAllByMemberEntityId(anyLong())).willReturn(List.of(completeQuestEntity1, completeQuestEntity2));
+
+        //when
+        List<CompleteQuestEntity> expectedList = completeQuestService.findAllByMemberId(1L);
+
+        //then
+        Assertions.assertThat(expectedList).containsExactly(completeQuestEntity1, completeQuestEntity2);
+    }
+
+}

--- a/offroad-api/src/test/java/site/offload/api/quest/service/ProceedingQuestServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/quest/service/ProceedingQuestServiceTest.java
@@ -1,0 +1,53 @@
+package site.offload.api.quest.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.offload.api.fixture.MemberEntityFixtureCreator;
+import site.offload.api.fixture.ProceedingQuestEntityFixture;
+import site.offload.db.member.entity.MemberEntity;
+import site.offload.db.quest.entity.ProceedingQuestEntity;
+import site.offload.db.quest.entity.QuestEntity;
+import site.offload.db.quest.repository.ProceedingQuestRepository;
+import site.offload.enums.member.SocialPlatform;
+import site.offload.enums.place.PlaceArea;
+import site.offload.enums.place.PlaceCategory;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static site.offload.api.fixture.QuestEntityFixtureCreator.createQuest;
+
+@ExtendWith(MockitoExtension.class)
+class ProceedingQuestServiceTest {
+
+    @InjectMocks
+    private ProceedingQuestService proceedingQuestService;
+
+    @Mock
+    private ProceedingQuestRepository proceedingQuestRepository;
+
+    @Test
+    @DisplayName("멤버 id로 모든 진행 중인 퀘스트를 조회할 수 있다.")
+    void findAllByMemberId() {
+        //given
+        MemberEntity memberEntity1 = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
+        QuestEntity questEntity1 = createQuest(true, "test", PlaceCategory.NONE, PlaceArea.NONE, 1);
+        QuestEntity questEntity2 = createQuest(false, "test", PlaceCategory.CAFFE, PlaceArea.NONE, 2);
+        ProceedingQuestEntity proceedingQuestEntity1 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity1);
+        ProceedingQuestEntity proceedingQuestEntity2 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity2);
+
+        given(proceedingQuestRepository.findAllByMemberEntityId(anyLong())).willReturn(List.of(proceedingQuestEntity1, proceedingQuestEntity2));
+
+        //when
+        List<ProceedingQuestEntity> expectedList = proceedingQuestService.findAllByMemberId(1L);
+
+        //then
+        Assertions.assertThat(expectedList).containsExactly(proceedingQuestEntity1, proceedingQuestEntity2);
+    }
+}

--- a/offroad-api/src/test/java/site/offload/api/quest/service/QuestServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/quest/service/QuestServiceTest.java
@@ -12,9 +12,11 @@ import site.offload.db.quest.repository.QuestRepository;
 import site.offload.enums.place.PlaceArea;
 import site.offload.enums.place.PlaceCategory;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static site.offload.api.fixture.QuestEntityFixtureCreator.createQuest;
@@ -45,4 +47,19 @@ class QuestServiceTest {
         assertThat(expectedQuestEntity).isEqualTo(questEntity);
     }
 
+    @Test
+    @DisplayName("특정 id 리스트가 포함되지 않은 퀘스트들을 조회할 수 있다")
+    void findByIdNotIn() {
+        //given
+        QuestEntity questEntity1 = createQuest(false, "test", PlaceCategory.CAFFE, PlaceArea.NONE, 1);
+        QuestEntity questEntity2 = createQuest(false, "test", PlaceCategory.NONE, PlaceArea.AREA1, 1);
+
+        given(questRepository.findByIdNotIn(anyCollection())).willReturn(List.of(questEntity1, questEntity2));
+
+        //when
+        List<QuestEntity> expectedList = questService.findByIdNotIn(List.of(1, 4));
+
+        //then
+        assertThat(expectedList).containsExactly(questEntity1, questEntity2);
+    }
 }

--- a/offroad-api/src/test/java/site/offload/api/quest/usecase/QuestUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/quest/usecase/QuestUseCaseTest.java
@@ -1,0 +1,130 @@
+package site.offload.api.quest.usecase;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.offload.api.fixture.CompleteQuestEntityFixture;
+import site.offload.api.fixture.MemberEntityFixtureCreator;
+import site.offload.api.fixture.ProceedingQuestEntityFixture;
+import site.offload.api.member.service.MemberService;
+import site.offload.api.quest.dto.response.QuestDetailListResponse;
+import site.offload.api.quest.dto.response.QuestDetailResponse;
+import site.offload.api.quest.service.CompleteQuestService;
+import site.offload.api.quest.service.ProceedingQuestService;
+import site.offload.api.quest.service.QuestService;
+import site.offload.db.member.entity.MemberEntity;
+import site.offload.db.quest.entity.CompleteQuestEntity;
+import site.offload.db.quest.entity.ProceedingQuestEntity;
+import site.offload.db.quest.entity.QuestEntity;
+import site.offload.enums.member.SocialPlatform;
+import site.offload.enums.place.PlaceArea;
+import site.offload.enums.place.PlaceCategory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+import static site.offload.api.fixture.QuestEntityFixtureCreator.createQuest;
+
+@ExtendWith(MockitoExtension.class)
+public class QuestUseCaseTest {
+
+    @InjectMocks
+    private QuestUseCase questUseCase;
+
+    @Mock
+    private QuestService questService;
+
+    @Mock
+    private ProceedingQuestService proceedingQuestService;
+
+    @Mock
+    private CompleteQuestService completeQuestService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("사용자는 진행중인 퀘스트를 달성도 기준 내림차순으로 조회할 수 있다")
+    void getCompletedQuestList() {
+
+        //given
+        MemberEntity memberEntity1 = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
+        QuestEntity questEntity1 = createQuest(true, "test1", PlaceCategory.NONE, PlaceArea.NONE, 100);
+        QuestEntity questEntity2 = createQuest(false, "test2", PlaceCategory.CAFFE, PlaceArea.NONE, 50);
+        QuestEntity questEntity3 = createQuest(false, "test3", PlaceCategory.CAFFE, PlaceArea.NONE, 10);
+
+        ProceedingQuestEntity proceedingQuestEntity1 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity1);
+        ProceedingQuestEntity proceedingQuestEntity2 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity2);
+        ProceedingQuestEntity proceedingQuestEntity3 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity3);
+
+        given(proceedingQuestService.findAllByMemberId(anyLong())).willReturn(List.of(proceedingQuestEntity1, proceedingQuestEntity2, proceedingQuestEntity3));
+
+        QuestDetailListResponse questDetailList = questUseCase.getQuestDetailList(1L, true);
+        List<QuestDetailResponse> actualResponse = questDetailList.questList();
+
+        List<String> expectedQuestNames = new ArrayList<>();
+        for (QuestDetailResponse questDetailResponse : actualResponse) {
+            expectedQuestNames.add(questDetailResponse.questName());
+        }
+
+        assertThat(expectedQuestNames).containsExactly("test3", "test2", "test1");
+    }
+
+    @Test
+    @DisplayName("사용자는 진행도 100% 미만 퀘스트를 목록 id오름차순으로 목록 위쪽에, 완료된 퀘스트를 아래쪽에서 조회할 수 있다")
+    void getAllQuest() {
+        // given
+        MemberEntity memberEntity1 = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
+        QuestEntity questEntity1 = Mockito.spy(createQuest(true, "test1", PlaceCategory.NONE, PlaceArea.NONE, 100));
+        QuestEntity questEntity2 = Mockito.spy(createQuest(false, "test2", PlaceCategory.CAFFE, PlaceArea.NONE, 50));
+        QuestEntity questEntity3 = Mockito.spy(createQuest(false, "test3", PlaceCategory.CAFFE, PlaceArea.NONE, 10));
+        QuestEntity questEntity4 = Mockito.spy(createQuest(false, "test4", PlaceCategory.CAFFE, PlaceArea.NONE, 10));
+
+        Mockito.doReturn(4).when(questEntity1).getId();
+        Mockito.doReturn(3).when(questEntity2).getId();
+        Mockito.doReturn(2).when(questEntity3).getId();
+        Mockito.doReturn(1).when(questEntity4).getId();
+
+        //questEntity1,2 완료 가정
+        CompleteQuestEntity completeQuestEntity1 = CompleteQuestEntityFixture.createCompleteQuestEntity(memberEntity1, questEntity1);
+        CompleteQuestEntity completeQuestEntity2 = CompleteQuestEntityFixture.createCompleteQuestEntity(memberEntity1, questEntity2);
+
+        //questEntity3 진행 중, questEntity4는 시작 전 가정(proceedingQuestEntity 없음)
+        ProceedingQuestEntity proceedingQuestEntity3 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity3);
+
+        given(memberService.findById(anyLong())).willReturn(memberEntity1);
+        given(completeQuestService.findAllByMemberId(anyLong())).willReturn(List.of(completeQuestEntity1, completeQuestEntity2));
+        given(questService.findByIdNotIn(anyList()))
+                .willReturn(List.of(questEntity3, questEntity4));
+
+        given(proceedingQuestService.existsByMemberAndQuest(memberEntity1, questEntity1)).willReturn(false);
+        given(proceedingQuestService.existsByMemberAndQuest(memberEntity1, questEntity2)).willReturn(false);
+        given(proceedingQuestService.existsByMemberAndQuest(memberEntity1, questEntity3)).willReturn(true);
+        given(proceedingQuestService.existsByMemberAndQuest(memberEntity1, questEntity4)).willReturn(false);
+
+        given(proceedingQuestService.findByMemberAndQuest(memberEntity1, questEntity3)).willReturn(proceedingQuestEntity3);
+
+        // when
+        QuestDetailListResponse result = questUseCase.getQuestDetailList(1L, false);
+
+        // then
+        // 완료된 퀘스트 test1, test2는 뒤 쪽에 있고 진행 중이거나 시작전인 퀘스트는 id 오름차순으로 앞쪽에 정렬
+        assertThat(result.questList())
+                .hasSize(4)
+                .extracting(QuestDetailResponse::questName)
+                .containsExactly("test4", "test3", "test1", "test2");
+
+        //각 퀘스트의 진행도 표시
+        assertThat(result.questList())
+                .extracting(QuestDetailResponse::currentCount)
+                .containsExactly(0, 1, 100, 50);
+
+    }
+
+}

--- a/offroad-db/src/main/java/site/offload/db/quest/entity/QuestEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/quest/entity/QuestEntity.java
@@ -29,6 +29,15 @@ public class QuestEntity extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PlaceArea placeArea;
 
+    @Column(nullable = false)
+    private String clearConditionText;
+
+    @Column(nullable = false)
+    private String rewardText;
+
+    @Column(nullable = false)
+    private String description;
+
     private boolean isQuestSamePlace = false;
 
     @Column(nullable = false)

--- a/offroad-db/src/main/java/site/offload/db/quest/repository/CompleteQuestRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/quest/repository/CompleteQuestRepository.java
@@ -6,8 +6,12 @@ import site.offload.db.member.entity.MemberEntity;
 import site.offload.db.quest.entity.CompleteQuestEntity;
 import site.offload.db.quest.entity.QuestEntity;
 
+import java.util.List;
+
 public interface CompleteQuestRepository extends JpaRepository<CompleteQuestEntity, Long> {
     void deleteAllByMemberEntityId(long memberId);
 
     boolean existsByQuestEntityAndMemberEntity(QuestEntity questEntity, MemberEntity memberEntity);
+
+    List<CompleteQuestEntity> findAllByMemberEntityId(long memberId);
 }

--- a/offroad-db/src/main/java/site/offload/db/quest/repository/ProceedingQuestRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/quest/repository/ProceedingQuestRepository.java
@@ -20,4 +20,6 @@ public interface ProceedingQuestRepository extends JpaRepository<ProceedingQuest
     void deleteByQuestEntityAndMemberEntity(QuestEntity questEntity, MemberEntity memberEntity);
 
     void deleteAllByMemberEntityId(long memberId);
+
+    List<ProceedingQuestEntity> findAllByMemberEntityId(long memberId);
 }

--- a/offroad-db/src/main/java/site/offload/db/quest/repository/QuestRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/quest/repository/QuestRepository.java
@@ -6,6 +6,7 @@ import site.offload.db.quest.entity.QuestEntity;
 import site.offload.enums.place.PlaceArea;
 import site.offload.enums.place.PlaceCategory;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface QuestRepository extends JpaRepository<QuestEntity, Integer> {
@@ -15,4 +16,6 @@ public interface QuestRepository extends JpaRepository<QuestEntity, Integer> {
     List<QuestEntity> findAllByPlaceArea(PlaceArea placeArea);
 
     List<QuestEntity> findAllByPlaceAreaAndPlaceCategory(PlaceArea placeArea, PlaceCategory placeCategory);
+
+    List<QuestEntity> findByIdNotIn(Collection<Integer> ids);
 }

--- a/offroad-enum/src/main/java/site/offload/enums/place/PlaceCategory.java
+++ b/offroad-enum/src/main/java/site/offload/enums/place/PlaceCategory.java
@@ -1,15 +1,22 @@
 package site.offload.enums.place;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.util.List;
 
 //장소 카테고리
+@RequiredArgsConstructor
+@Getter
 public enum PlaceCategory {
-    CAFFE,
-    PARK,
-    RESTAURANT,
-    CULTURE,
-    SPORT,
-    NONE;
+    CAFFE("카페"),
+    PARK("공원"),
+    RESTAURANT("식당"),
+    CULTURE("문화"),
+    SPORT("스포츠"),
+    NONE("카테고리 없음");
+
+    private final String placeCategoryName;
 
     public static boolean isExistsCategory(final String placeCategory) {
         for (PlaceCategory category : PlaceCategory.values()) {

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -21,6 +21,7 @@ public enum SuccessMessage {
     GET_GAINED_EMBLEMS_SUCCESS("보유 칭호 목록 조회 완료"),
     GET_CHARACTERS_LIST_SUCCESS("캐릭터 목록 조회 완료"),
     GET_QUEST_INFORMATION_SUCCESS("퀘스트 정보 조회 성공"),
+    GET_QUEST_DETAIL_LIST_SUCCESS("퀘스트 목록 조회 성공"),
     AUTHENTICATE_ADVENTURE_REQUEST_SUCCESS("탐험 인증 요청 성공"),
     GET_GAINED_CHARACTERS_SUCCESS("캐릭터 조회 성공"),
     GET_COUPON_LIST_SUCCESS("획득 쿠폰 조회 요청 성공"),


### PR DESCRIPTION
## 변경사항
- QuestEntity에 보상, 달성 조건, 설명을 나타낼 수 있는 text 관련 필드를 추가했습니다
## 고려사항
- 화면에 보여지는 보상, 달성 조건 텍스트의 경우 필드를 추가하지 않고 앱에서 처리할 지 아니면 필드를 추가할지 고민하다,
퀘스트 개수가 그렇게 많지 않은 것과 문자열을 다루는 구현의 복잡성 때문에 필드에 추가하는 방식을 선택했습니다
## Comment
- 화면 설계서 요구사항에 따라 퀘스트들을 정렬해서 응답합니다
- 퀘스트 달성 조건, 쿠폰의 정확한 텍스트 형식은 아직 정하지 않은거 같아 예시로 남겼습니다
## Test
<img width="566" alt="image" src="https://github.com/user-attachments/assets/466f1ee2-472f-4653-ba71-3359f6787ca5">


<img width="245" alt="image" src="https://github.com/user-attachments/assets/5916bf56-4e30-42fe-8802-fb1b60be359c">

## 질문사항

