### PR TITLE
[feat]: 마케팅 수신 여부 동의 API 

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
@@ -81,4 +81,13 @@ public class MemberController implements MemberControllerSwagger {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_USER_INFO_SUCCESS.getMessage(), memberUseCase.getUserInfo(memberId));
     }
+
+    @PatchMapping("/tos")
+    public ResponseEntity<APISuccessResponse<Void>> agreeMarketing(
+            @RequestBody MarketingAgreeRequest marketingAgreeRequest
+    ) {
+        final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
+        memberUseCase.updateAgreeMarketing(memberId, marketingAgreeRequest.marketing());
+        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.CHECK_AGREE_MARKETING_SUCCESS.getMessage(), null);
+    }
 }

--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
@@ -82,7 +82,7 @@ public class MemberController implements MemberControllerSwagger {
         return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_USER_INFO_SUCCESS.getMessage(), memberUseCase.getUserInfo(memberId));
     }
 
-    @PatchMapping("/tos")
+    @PatchMapping("/marketing")
     public ResponseEntity<APISuccessResponse<Void>> agreeMarketing(
             @RequestBody MarketingAgreeRequest marketingAgreeRequest
     ) {

--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
@@ -8,10 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import site.offload.api.member.dto.request.AuthAdventureRequest;
-import site.offload.api.member.dto.request.AuthPositionRequest;
-import site.offload.api.member.dto.request.MemberProfileUpdateRequest;
-import site.offload.api.member.dto.request.SignOutRequest;
+import site.offload.api.member.dto.request.*;
 import site.offload.api.member.dto.response.*;
 import site.offload.api.response.APISuccessResponse;
 
@@ -50,6 +47,12 @@ public interface MemberControllerSwagger {
     @Operation(summary = "캐릭터 목록 조회 API", description = "캐릭터 목록 조회 API")
     @ApiResponse(responseCode = "200", description = "캐릭터 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
     public ResponseEntity<APISuccessResponse<GainedCharactersResponse>> getGainedCharacters();
+
+    @Operation(summary = "마케팅 수신 여부 API", description = "마케팅 수신 여부 API")
+    @ApiResponse(responseCode = "200", description = "마케팅 수신 여부 업데이트 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    public ResponseEntity<APISuccessResponse<Void>> agreeMarketing(
+            @RequestBody MarketingAgreeRequest marketingAgreeRequest
+    );
 }
 
 

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/MarketingAgreeRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/MarketingAgreeRequest.java
@@ -1,0 +1,6 @@
+package site.offload.api.member.dto.request;
+
+public record MarketingAgreeRequest(
+        boolean marketing
+) {
+}

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -158,5 +158,11 @@ public class MemberUseCase {
         return gainedCharacterMotionService.isExistByCharacterMotionAndMember(characterMotionEntity, memberEntity);
     }
 
+    @Transactional
+    public void updateAgreeMarketing(Long memberId, boolean isAgreeMarketing) {
+        MemberEntity findMemberEntity = memberService.findById(memberId);
+        findMemberEntity.updateAgreeMarketing(isAgreeMarketing);
+    }
+
 }
 

--- a/offroad-api/src/test/java/site/offload/api/member/usecase/MemberUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/member/usecase/MemberUseCaseTest.java
@@ -1,0 +1,38 @@
+package site.offload.api.member.usecase;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.offload.api.member.service.MemberService;
+import site.offload.db.member.entity.MemberEntity;
+import site.offload.enums.member.SocialPlatform;
+
+import static org.mockito.ArgumentMatchers.any;
+import static site.offload.api.fixture.MemberEntityFixtureCreator.createMemberEntity;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberUseCaseTest {
+
+    @InjectMocks
+    MemberUseCase memberUseCase;
+
+    @Mock
+    MemberService memberService;
+
+    @Test
+    @DisplayName("마케팅 수신 여부를 적용할 수 있다.")
+    void applyMarketingAgree() {
+        //given
+        MemberEntity memberEntity = createMemberEntity("example sub", "example@offroad.com", SocialPlatform.GOOGLE, "이름");
+        BDDMockito.given(memberService.findById(any())).willReturn(memberEntity);
+        //when
+        memberUseCase.updateAgreeMarketing(1L, false);
+        //then
+        Assertions.assertThat(memberEntity.isAgreeMarketing()).isEqualTo(false);
+    }
+}

--- a/offroad-db/src/main/java/site/offload/db/member/entity/MemberEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/member/entity/MemberEntity.java
@@ -59,6 +59,8 @@ public class MemberEntity extends BaseTimeEntity {
     @Embedded
     private Birthday birthday;
 
+    private boolean isAgreeMarketing;
+
     @Builder
     public MemberEntity(String name, String email, String sub, SocialPlatform socialPlatform) {
         this.name = name;
@@ -79,6 +81,10 @@ public class MemberEntity extends BaseTimeEntity {
 
     public void chooseCharacter(String characterName) {
         this.currentCharacterName = characterName;
+    }
+
+    public void updateAgreeMarketing(boolean isAgreeMarketing) {
+        this.isAgreeMarketing = isAgreeMarketing;
     }
 
 }

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -10,7 +10,7 @@ public enum SuccessMessage {
     SOCIAL_LOGIN_SUCCESS("로그인 요청 성공"),
     SIGN_OUT_SUCCESS("로그아웃 성공"),
     DELETE_TEST_MEMBER_SUCCESS("테스트 회원 삭제 성공"),
-
+    CHECK_AGREE_MARKETING_SUCCESS("마케팅 정보 수신 여부 확인 완료"),
     ACCESS_TOKEN_REFRESH_SUCCESS("Access Token 재발급 성공"),
     MEMBER_ADVENTURE_INFORMATION_SUCCESS("모험 정보 조회 성공"),
     CHECK_REGISTERED_PLACES_SUCCESS("장소 리스트 정보 조회 성공"),


### PR DESCRIPTION
## 변경사항

### 마케팅 수신 여부 확인 API
* 마케팅 수신 여부 확인 API를 작성했습니다.
* 개인정보 수집 동의, 위치 기반 동의 등 4가지 약관 중 3가지는 필수고 마케팅만 선택이었기 때문에 마케팅 여부만 확인하도록 했습니다.
* MemberEntity내부에 마케팅 수신 여부를 나타내는 boolean값과 이를 update하는 메소드를 추가했습니다.


