### PR TITLE
[feat] : 신규 획득 여부 갱신 구현

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/charactermotion/usecase/CharacterMotionUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/charactermotion/usecase/CharacterMotionUseCase.java
@@ -11,6 +11,8 @@ import site.offload.api.charactermotion.service.GainedCharacterMotionService;
 import site.offload.api.member.service.MemberService;
 import site.offload.db.character.entity.CharacterEntity;
 import site.offload.db.charactermotion.entity.CharacterMotionEntity;
+import site.offload.db.charactermotion.entity.GainedCharacterMotionEntity;
+import site.offload.db.emblem.entity.GainedEmblemEntity;
 import site.offload.db.member.entity.MemberEntity;
 import site.offload.external.aws.S3Service;
 
@@ -34,7 +36,12 @@ public class CharacterMotionUseCase {
 
         List<CharacterMotionResponse> gainedCharacterMotions = characterMotionEntities.stream()
                 .filter(characterMotionEntity -> gainedCharacterMotionService.isExistByCharacterMotionAndMember(characterMotionEntity, findMemberEntity))
-                .map(characterMotionEntity -> CharacterMotionResponse.of(characterMotionEntity.getPlaceCategory().toString(), s3Service.getPresignUrl(characterMotionEntity.getMotionCaptureImageUrl()), gainedCharacterMotionService.findByMemberEntityAndCharacterMotionEntity(findMemberEntity, characterMotionEntity).isNewGained()))
+                .map(characterMotionEntity -> {
+                    GainedCharacterMotionEntity gainedCharacterMotionEntity = gainedCharacterMotionService.findByMemberEntityAndCharacterMotionEntity(findMemberEntity, characterMotionEntity);
+                    boolean isNewGained = gainedCharacterMotionEntity.isNewGained();
+                    gainedCharacterMotionEntity.updateNewGainedStatus();
+                    return CharacterMotionResponse.of(characterMotionEntity.getPlaceCategory().toString(), s3Service.getPresignUrl(characterMotionEntity.getMotionCaptureImageUrl()), isNewGained);
+                })
                 .toList();
 
         List<CharacterMotionResponse> notGainedCharacterMotions = characterMotionEntities.stream()

--- a/offroad-api/src/main/java/site/offload/api/coupon/usecase/CouponListUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/usecase/CouponListUseCase.java
@@ -34,13 +34,15 @@ public class CouponListUseCase {
                 gainedCouponEntity -> {
                     if (!gainedCouponEntity.isUsed()) {
                         final CouponEntity couponEntity = gainedCouponEntity.getCouponEntity();
+                        boolean isNewGained = gainedCouponEntity.isNewGained();
+                        gainedCouponEntity.updateNewGainedStatus();
                         availableCouponList.add(
                                 AvailableCouponResponse.of(
                                         couponEntity.getId(),
                                         couponEntity.getName(),
                                         couponEntity.getCouponImageUrl(),
                                         couponEntity.getDescription(),
-                                        gainedCouponEntity.isNewGained())
+                                        isNewGained)
                         );
                     }
                 }

--- a/offroad-api/src/main/java/site/offload/api/emblem/usecase/EmblemUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/usecase/EmblemUseCase.java
@@ -69,7 +69,12 @@ public class EmblemUseCase {
 
         List<EmblemResponse> gainedEmblems = questRewardEntitiesWithEmblems.stream()
                 .filter(questRewardEntityWithEmblem -> emblemCodes.contains(questRewardEntityWithEmblem.getRewardList().getEmblemCode()))
-                .map(questRewardEntity -> EmblemResponse.of(Emblem.getEmblemByCode(questRewardEntity.getRewardList().getEmblemCode()).getEmblemName(), questService.findById(questRewardEntity.getQuestId()).getName(), gainedEmblemService.findByMemberIdAndEmblemCode(memberId, questRewardEntity.getRewardList().getEmblemCode()).isNewGained()))
+                .map(questRewardEntity -> {
+                    GainedEmblemEntity gainedEmblemEntity = gainedEmblemService.findByMemberIdAndEmblemCode(memberId, questRewardEntity.getRewardList().getEmblemCode());
+                    boolean isNewGained = gainedEmblemEntity.isNewGained();
+                    gainedEmblemEntity.updateNewGainedStatus();
+                    return EmblemResponse.of(Emblem.getEmblemByCode(questRewardEntity.getRewardList().getEmblemCode()).getEmblemName(), questService.findById(questRewardEntity.getQuestId()).getName(), isNewGained);
+                })
                 .toList();
 
         List<EmblemResponse> notGainedEmblems = questRewardEntitiesWithEmblems.stream()

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -19,7 +19,9 @@ import site.offload.api.place.service.VisitedPlaceService;
 import site.offload.api.quest.service.CompleteQuestService;
 import site.offload.api.util.TimeUtil;
 import site.offload.db.character.entity.CharacterEntity;
+import site.offload.db.character.entity.GainedCharacterEntity;
 import site.offload.db.charactermotion.entity.CharacterMotionEntity;
+import site.offload.db.charactermotion.entity.GainedCharacterMotionEntity;
 import site.offload.db.member.embeddable.Birthday;
 import site.offload.db.member.entity.MemberEntity;
 import site.offload.enums.place.PlaceCategory;
@@ -111,7 +113,12 @@ public class MemberUseCase {
 
         List<GainedCharacterResponse> gainedCharacters = characterEntities.stream()
                 .filter(characterEntity -> gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity))
-                .map(characterEntity -> GainedCharacterResponse.of(characterEntity.getId(), characterEntity.getName(), s3Service.getPresignUrl(characterEntity.getCharacterBaseImageUrl()), characterEntity.getCharacterMainColorCode(), characterEntity.getCharacterSubColorCode(), gainedCharacterService.findByMemberEntityAndCharacterEntity(memberEntity, characterEntity).isNewGained()))
+                .map(characterEntity -> {
+                    GainedCharacterEntity gainedCharacterEntity = gainedCharacterService.findByMemberEntityAndCharacterEntity(memberEntity, characterEntity);
+                    boolean isNewGained = gainedCharacterEntity.isNewGained();
+                    gainedCharacterEntity.updateNewGainedStatus();
+                    return GainedCharacterResponse.of(characterEntity.getId(), characterEntity.getName(), s3Service.getPresignUrl(characterEntity.getCharacterBaseImageUrl()), characterEntity.getCharacterMainColorCode(), characterEntity.getCharacterSubColorCode(), isNewGained);
+                })
                 .collect(Collectors.toList());
 
         List<GainedCharacterResponse> notGainedCharacters = characterEntities.stream()

--- a/offroad-api/src/test/java/site/offload/api/charactermotion/usecase/CharacterMotionUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/charactermotion/usecase/CharacterMotionUseCaseTest.java
@@ -102,7 +102,7 @@ public class CharacterMotionUseCaseTest {
     }
 
     @Test
-    @DisplayName("새롭게 얻은 캐릭터 모션은 캐릭터 최초 응답 이후 이전에 얻은 모션으로 바뀐다.")
+    @DisplayName("신규 획득한 캐릭터 모션은 첫 번째 조회 이후 신규 획득 여부가 변경된다.")
     void changeMotionFromNewToOld() {
         //given
         MemberEntity memberEntity = MemberEntity.builder().name("이름1").email("이메일1").sub("소셜아이디1").socialPlatform(SocialPlatform.GOOGLE).build();

--- a/offroad-api/src/test/java/site/offload/api/coupon/usecase/CouponListUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/coupon/usecase/CouponListUseCaseTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static site.offload.api.fixture.CouponEntityFixtureCreator.createCoupon;
@@ -75,9 +76,6 @@ class CouponListUseCaseTest {
                 .willReturn(gainedCouponList);
 
         // when
-        CouponListResponse response = couponListUseCase.getCouponList(1L);
-
-        // then
         List<AvailableCouponResponse> expectedAvailableCoupons = List.of(
                 AvailableCouponResponse.of(
                         couponEntity4.getId(),
@@ -106,8 +104,13 @@ class CouponListUseCaseTest {
                 )
         );
 
+        CouponListResponse response = couponListUseCase.getCouponList(1L);
+
+        // then
+
         assertEquals(expectedAvailableCoupons, response.availableCoupons());
         assertEquals(expectedUsedCoupons, response.usedCoupons());
+        assertFalse(gainedCouponEntity4.isNewGained());
     }
 
     private void setGainedCouponEntityCreatedAt(GainedCouponEntity entity, LocalDateTime createdAt) throws Exception {

--- a/offroad-db/src/main/java/site/offload/db/character/entity/GainedCharacterEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/character/entity/GainedCharacterEntity.java
@@ -37,4 +37,8 @@ public class GainedCharacterEntity extends BaseTimeEntity {
         this.memberEntity = memberEntity;
         this.characterEntity = characterEntity;
     }
+
+    public void updateNewGainedStatus() {
+        this.isNewGained = false;
+    }
 }

--- a/offroad-db/src/main/java/site/offload/db/charactermotion/entity/GainedCharacterMotionEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/charactermotion/entity/GainedCharacterMotionEntity.java
@@ -35,4 +35,8 @@ public class GainedCharacterMotionEntity extends BaseTimeEntity {
         this.memberEntity = memberEntity;
         this.characterMotionEntity = characterMotionEntity;
     }
+
+    public void updateNewGainedStatus() {
+        this.isNewGained = false;
+    }
 }

--- a/offroad-db/src/main/java/site/offload/db/coupon/entity/GainedCouponEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/coupon/entity/GainedCouponEntity.java
@@ -48,4 +48,8 @@ public class GainedCouponEntity extends BaseTimeEntity {
     public void updateIsUsed(boolean isUsed) {
         this.isUsed = isUsed;
     }
+
+    public void updateNewGainedStatus() {
+        this.isNewGained = false;
+    }
 }

--- a/offroad-db/src/main/java/site/offload/db/emblem/entity/GainedEmblemEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/emblem/entity/GainedEmblemEntity.java
@@ -15,8 +15,8 @@ import site.offload.db.member.entity.MemberEntity;
 @Table(
         name = "gained_emblem",
         uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"member_id", "emblem_code"})
-})
+                @UniqueConstraint(columnNames = {"member_id", "emblem_code"})
+        })
 public class GainedEmblemEntity extends BaseTimeEntity {
 
     @Id
@@ -40,5 +40,9 @@ public class GainedEmblemEntity extends BaseTimeEntity {
 
     public static GainedEmblemEntity create(MemberEntity memberEntity, String emblemCode) {
         return new GainedEmblemEntity(memberEntity, emblemCode);
+    }
+
+    public void updateNewGainedStatus() {
+        this.isNewGained = false;
     }
 }


### PR DESCRIPTION
## 변경사항

### 신규 획득 여부 갱신

* 신규 획득 여부를 응답한 후에 더 이상 신규 획득이 아님을 나타낼 수 있도록 갱신하게 했습니다.
* 캐릭터, 캐릭터모션, 쿠폰, 칭호 usecase에서 Gained~Entity에 원래 상태를 먼저 저장한 후 이를 반환하도록 설정했습니다.
* 저장 후 더 이상 신규 획득이 아니기 때문에 상태를 업데이트 해주는 메소드를 이용해 업데이트 했습니다.

## 고려사항

* 클릭 시 New상태가 아니라는 조건이 있긴 했지만, 클릭시에도 페이지를 벗어나는 것은 똑같다고 판단하여서 이러한 메소드들을 추가했습니다.

