### PR TITLE
[feat]: 카카오 소셜 로그인 API 구현

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/member/usecase/SocialLoginUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/SocialLoginUseCase.java
@@ -32,6 +32,7 @@ public class SocialLoginUseCase {
     private final KakaoSocialLoginService kakaoSocialLoginService;
     private final GainedEmblemService gainedEmblemService;
     private final MemberService memberService;
+    private final MemberStatusCacheService memberStatusCacheService;
 
     @Transactional
     public SocialLoginResponse login(SocialLoginRequest socialLoginRequest) {
@@ -47,6 +48,7 @@ public class SocialLoginUseCase {
                 } else {
                     isAlreadyExist = true;
                 }
+                memberStatusCacheService.saveMemberStatus(MemberStatus.ACTIVE.name(), memberEntity.getId());
             } else {
                 memberEntity = MemberEntity.builder()
                         .name(googleInfoResponse.name())
@@ -56,6 +58,7 @@ public class SocialLoginUseCase {
                         .build();
                 memberService.saveMember(memberEntity);
                 isAlreadyExist = false;
+                memberStatusCacheService.saveMemberStatus(MemberStatus.ACTIVE.name(), memberEntity.getId());
             }
         } else if (socialPlatFormRequest.equals(SocialPlatform.APPLE.getSocialPlatform())) {
             Claims appleInfoResponse = appleSocialLoginService.login(socialLoginRequest);
@@ -66,6 +69,7 @@ public class SocialLoginUseCase {
                 } else {
                     isAlreadyExist = true;
                 }
+                memberStatusCacheService.saveMemberStatus(MemberStatus.ACTIVE.name(), memberEntity.getId());
             } else {
                 memberEntity = MemberEntity.builder()
                         .name(socialLoginRequest.name())
@@ -75,6 +79,7 @@ public class SocialLoginUseCase {
                         .build();
                 memberService.saveMember(memberEntity);
                 isAlreadyExist = false;
+                memberStatusCacheService.saveMemberStatus(MemberStatus.ACTIVE.name(), memberEntity.getId());
             }
         } else if (socialPlatFormRequest.equals(SocialPlatform.KAKAO.getSocialPlatform())) {
             KakaoInfoResponse kakaoInfoResponse = kakaoSocialLoginService.login(socialLoginRequest);
@@ -85,6 +90,7 @@ public class SocialLoginUseCase {
                 } else {
                     isAlreadyExist = true;
                 }
+                memberStatusCacheService.saveMemberStatus(MemberStatus.ACTIVE.name(), memberEntity.getId());
             } else {
                 memberEntity = MemberEntity.builder()
                         .name(kakaoInfoResponse.kakaoAccount().get("name").toString())
@@ -94,8 +100,8 @@ public class SocialLoginUseCase {
                         .build();
                 memberService.saveMember(memberEntity);
                 isAlreadyExist = false;
+                memberStatusCacheService.saveMemberStatus(MemberStatus.ACTIVE.name(), memberEntity.getId());
             }
-
         }
 
         try {

--- a/offroad-api/src/main/resources/application-dev.yaml
+++ b/offroad-api/src/main/resources/application-dev.yaml
@@ -45,6 +45,10 @@ apple:
   iss: ${APPLE_ISS}
   client-id: ${APPLE_CLIENT_ID}
 
+kakao:
+  client-id: ${KAKAO_CLIENT_ID_DEV}
+  redirect-uri: ${KAKAO_REDIRECT_URI_DEV}
+
 logging:
   level:
     org.springframework: DEBUG

--- a/offroad-api/src/main/resources/application-local.yaml
+++ b/offroad-api/src/main/resources/application-local.yaml
@@ -46,3 +46,7 @@ aws-property:
 logging:
   level:
     root: info
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID_DEV}
+  redirect-uri: ${KAKAO_REDIRECT_URI_DEV}

--- a/offroad-enum/src/main/java/site/offload/enums/member/SocialPlatform.java
+++ b/offroad-enum/src/main/java/site/offload/enums/member/SocialPlatform.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SocialPlatform {
-    GOOGLE("google"),
-    APPLE("apple");
+    GOOGLE("GOOGLE"),
+    APPLE("APPLE"),
+    KAKAO("KAKAO");
     private final String socialPlatform;
 }

--- a/offroad-external/src/main/java/site/offload/external/oauth/dto/SocialLoginRequest.java
+++ b/offroad-external/src/main/java/site/offload/external/oauth/dto/SocialLoginRequest.java
@@ -4,11 +4,11 @@ package site.offload.external.oauth.dto;
 import site.offload.external.enums.SocialPlatform;
 
 public record SocialLoginRequest(
-        SocialPlatform socialPlatform,
+        String socialPlatform,
         String name,
         String code
 ) {
-    public static SocialLoginRequest of(SocialPlatform socialPlatform, String name, String code) {
+    public static SocialLoginRequest of(String socialPlatform, String name, String code) {
         return new SocialLoginRequest(socialPlatform, name, code);
     }
 }

--- a/offroad-external/src/main/java/site/offload/external/oauth/kakao/KakaoSocialLoginService.java
+++ b/offroad-external/src/main/java/site/offload/external/oauth/kakao/KakaoSocialLoginService.java
@@ -1,0 +1,36 @@
+package site.offload.external.oauth.kakao;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import site.offload.external.oauth.dto.SocialLoginRequest;
+import site.offload.external.oauth.kakao.request.KakaoAccessTokenClient;
+import site.offload.external.oauth.kakao.request.KakaoInfoClient;
+import site.offload.external.oauth.kakao.response.KakaoInfoResponse;
+import site.offload.external.oauth.kakao.response.KakaoAccessTokenResponse;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoSocialLoginService {
+
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+    @Value("${kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    private final KakaoAccessTokenClient kakaoAccessTokenClient;
+    private final KakaoInfoClient kakaoInfoClient;
+
+    public KakaoInfoResponse login(SocialLoginRequest socialLoginRequest) {
+        KakaoAccessTokenResponse kakaoAccessTokenResponse = kakaoAccessTokenClient.kakaoAuth(
+                "application/x-www-form-urlencoded;charset=utf-8",
+                socialLoginRequest.code(),
+                kakaoClientId,
+                kakaoRedirectUri,
+                "authorization_code"
+        );
+        return kakaoInfoClient.kakaoInfo("Bearer " + kakaoAccessTokenResponse.accessToken(), "application/x-www-form-urlencoded;charset=utf-8");
+    }
+}

--- a/offroad-external/src/main/java/site/offload/external/oauth/kakao/request/KakaoAccessTokenClient.java
+++ b/offroad-external/src/main/java/site/offload/external/oauth/kakao/request/KakaoAccessTokenClient.java
@@ -1,0 +1,19 @@
+package site.offload.external.oauth.kakao.request;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import site.offload.external.oauth.kakao.response.KakaoAccessTokenResponse;
+
+@FeignClient(value = "kakaoClient", url = "https://kauth.kakao.com/oauth/token")
+public interface KakaoAccessTokenClient {
+
+    @PostMapping
+    KakaoAccessTokenResponse kakaoAuth(
+            @RequestHeader(name = "Content-type") String contentType,
+            @RequestParam(name = "code") String code,
+            @RequestParam(name = "client_id") String clientId,
+            @RequestParam(name = "redirect_uri") String redirectUri,
+            @RequestParam(name = "grant_type") String grantType);
+}

--- a/offroad-external/src/main/java/site/offload/external/oauth/kakao/request/KakaoInfoClient.java
+++ b/offroad-external/src/main/java/site/offload/external/oauth/kakao/request/KakaoInfoClient.java
@@ -1,0 +1,17 @@
+package site.offload.external.oauth.kakao.request;
+
+import lombok.Getter;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import site.offload.external.oauth.kakao.response.KakaoInfoResponse;
+
+@FeignClient(value = "kakaoInfoClient", url = "https://kapi.kakao.com/v2/user/me")
+public interface KakaoInfoClient {
+
+    @GetMapping
+    KakaoInfoResponse kakaoInfo(
+            @RequestHeader("Authorization") String token,
+            @RequestHeader(name = "Content-type") String contentType
+    );
+}

--- a/offroad-external/src/main/java/site/offload/external/oauth/kakao/response/KakaoAccessTokenResponse.java
+++ b/offroad-external/src/main/java/site/offload/external/oauth/kakao/response/KakaoAccessTokenResponse.java
@@ -1,0 +1,10 @@
+package site.offload.external.oauth.kakao.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoAccessTokenResponse(
+        String accessToken
+) {
+}

--- a/offroad-external/src/main/java/site/offload/external/oauth/kakao/response/KakaoInfoResponse.java
+++ b/offroad-external/src/main/java/site/offload/external/oauth/kakao/response/KakaoInfoResponse.java
@@ -1,0 +1,13 @@
+package site.offload.external.oauth.kakao.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.Map;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoInfoResponse(
+        String id,
+        Map<String, Object> kakaoAccount
+) {
+}


### PR DESCRIPTION
## 변경사항

### 카카오 소셜 로그인 API 구현 

* 카카오 소셜 로그인 API를 FeignClient를 사용하여 구현했습니다.

* JSON parse error: Cannot deserialize value of type라는 에러가 발생하여 소셜 플랫폼의 분기처리에서 수정을 하였습니다.

## 고려사항

* yaml파일이 수정됨에 따라서 github actions 또한 수정이 필요합니다. 

* 현재 이용중인 client-id는 테스트 앱의 어플리케이션입니다. 그렇기에 나중에 본 앱을 이용하기 위해서는 yaml파일에서 redirect-uri와 client-id의 수정이 필요합니다.

* 테스트 앱이 아닌 본 앱에서 개인정보 동의항목에 이름을 추가시키려면 사업자 번호가 있어야 하는데 이에 대해서 어떻게 처리해야 할지 논의하면 좋을 것 같습니다.

