### PR TITLE
refactor: 장소 조회 API 수정

### DIFF
--- a/offroad-api/build.gradle
+++ b/offroad-api/build.gradle
@@ -1,8 +1,7 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/AuthAdventureUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/AuthAdventureUseCase.java
@@ -187,7 +187,7 @@ public class AuthAdventureUseCase {
 
             //'같은 장소' 여러번 방문이 조건인 퀘스트인 경우
         } else {
-            final long count = visitedPlaceService.countByMemberAndPlace(findMemberEntity, findPlaceEntity);
+            final long count = visitedPlaceService.countMemberAndPlace(findMemberEntity, findPlaceEntity);
             proceedingQuestService.updateCurrentClearCount(proceedingQuestEntity, (int) count);
         }
         return proceedingQuestEntity;

--- a/offroad-api/src/main/java/site/offload/api/place/controller/PlaceController.java
+++ b/offroad-api/src/main/java/site/offload/api/place/controller/PlaceController.java
@@ -9,10 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.offload.api.auth.PrincipalHandler;
-import site.offload.api.place.dto.request.RegisteredPlacesRequest;
-import site.offload.api.place.dto.request.UnvisitedPlacesRequest;
 import site.offload.api.place.dto.response.RegisteredPlacesResponse;
-import site.offload.api.place.dto.response.UnvisitedPlacesResponse;
 import site.offload.api.place.usecase.PlaceUseCase;
 import site.offload.api.response.APISuccessResponse;
 import site.offload.enums.response.SuccessMessage;
@@ -26,25 +23,15 @@ public class PlaceController implements PlaceControllerSwagger {
     private final PlaceUseCase placeUsecase;
 
     @GetMapping("/places")
-    public ResponseEntity<APISuccessResponse<RegisteredPlacesResponse>> checkRegisteredPlaces(
+    public ResponseEntity<APISuccessResponse<RegisteredPlacesResponse>> getPlaces(
             @RequestParam double currentLatitude,
-            @RequestParam double currentLongitude
+            @RequestParam double currentLongitude,
+            @RequestParam int limit,
+            @RequestParam Boolean isBounded
     ) {
         return APISuccessResponse.of(
                 HttpStatus.OK.value(),
                 SuccessMessage.CHECK_REGISTERED_PLACES_SUCCESS.getMessage(),
-                placeUsecase.checkRegisteredPlaces(PrincipalHandler.getMemberIdFromPrincipal(),
-                        RegisteredPlacesRequest.of(currentLatitude, currentLongitude)));
-    }
-
-    @GetMapping("/places/unvisited")
-    public ResponseEntity<APISuccessResponse<UnvisitedPlacesResponse>> getUnvisitedPlacesResponse(
-            @RequestParam double currentLatitude,
-            @RequestParam double currentLongitude
-    ) {
-        return APISuccessResponse.of(
-                HttpStatus.OK.value(),
-                SuccessMessage.CHECK_UNVISITED_PLACES_SUCCESS.getMessage(),
-                placeUsecase.checkUnvisitedPlaces(PrincipalHandler.getMemberIdFromPrincipal(), UnvisitedPlacesRequest.of(currentLatitude, currentLongitude)));
+                placeUsecase.getPlaces(PrincipalHandler.getMemberIdFromPrincipal(), currentLatitude, currentLongitude, limit, isBounded));
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/place/controller/PlaceController.java
+++ b/offroad-api/src/main/java/site/offload/api/place/controller/PlaceController.java
@@ -10,7 +10,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.offload.api.auth.PrincipalHandler;
 import site.offload.api.place.dto.request.RegisteredPlacesRequest;
+import site.offload.api.place.dto.request.UnvisitedPlacesRequest;
 import site.offload.api.place.dto.response.RegisteredPlacesResponse;
+import site.offload.api.place.dto.response.UnvisitedPlacesResponse;
 import site.offload.api.place.usecase.PlaceUseCase;
 import site.offload.api.response.APISuccessResponse;
 import site.offload.enums.response.SuccessMessage;
@@ -26,13 +28,23 @@ public class PlaceController implements PlaceControllerSwagger {
     @GetMapping("/places")
     public ResponseEntity<APISuccessResponse<RegisteredPlacesResponse>> checkRegisteredPlaces(
             @RequestParam double currentLatitude,
-            @RequestParam double currentLongitude,
-            @RequestParam Boolean isVisit
-            ) {
+            @RequestParam double currentLongitude
+    ) {
         return APISuccessResponse.of(
                 HttpStatus.OK.value(),
                 SuccessMessage.CHECK_REGISTERED_PLACES_SUCCESS.getMessage(),
                 placeUsecase.checkRegisteredPlaces(PrincipalHandler.getMemberIdFromPrincipal(),
-                RegisteredPlacesRequest.of(currentLatitude, currentLongitude, isVisit)));
+                        RegisteredPlacesRequest.of(currentLatitude, currentLongitude)));
+    }
+
+    @GetMapping("/places/unvisited")
+    public ResponseEntity<APISuccessResponse<UnvisitedPlacesResponse>> getUnvisitedPlacesResponse(
+            @RequestParam double currentLatitude,
+            @RequestParam double currentLongitude
+    ) {
+        return APISuccessResponse.of(
+                HttpStatus.OK.value(),
+                SuccessMessage.CHECK_UNVISITED_PLACES_SUCCESS.getMessage(),
+                placeUsecase.checkUnvisitedPlaces(PrincipalHandler.getMemberIdFromPrincipal(), UnvisitedPlacesRequest.of(currentLatitude, currentLongitude)));
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/place/controller/PlaceControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/place/controller/PlaceControllerSwagger.java
@@ -4,10 +4,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import site.offload.api.auth.PrincipalHandler;
+import site.offload.api.place.dto.request.UnvisitedPlacesRequest;
 import site.offload.api.place.dto.response.RegisteredPlacesResponse;
+import site.offload.api.place.dto.response.UnvisitedPlacesResponse;
 import site.offload.api.response.APISuccessResponse;
+import site.offload.enums.response.SuccessMessage;
 
 public interface PlaceControllerSwagger {
     @Operation(summary = "오프로드 등록 장소 조회 API", description = "오프로드 등록 장소 조회 API입니다.")
@@ -16,7 +22,20 @@ public interface PlaceControllerSwagger {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
             ResponseEntity<APISuccessResponse<RegisteredPlacesResponse>> checkRegisteredPlaces(
             @RequestParam double currentLatitude,
-            @RequestParam double currentLongitude,
-            @RequestParam Boolean isVisit
+            @RequestParam double currentLongitude
+    );
+
+
+    @Operation(summary = "방문하지 않은 장소 조회 API", description = "방문하지 않은 장소 조회 API입니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "방문하지 않은 장소 조회 완료",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class))
+
+    )
+    @GetMapping("/places/unvisited")
+    ResponseEntity<APISuccessResponse<UnvisitedPlacesResponse>> getUnvisitedPlacesResponse(
+            @RequestParam double currentLatitude,
+            @RequestParam double currentLongitude
     );
 }

--- a/offroad-api/src/main/java/site/offload/api/place/controller/PlaceControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/place/controller/PlaceControllerSwagger.java
@@ -20,22 +20,10 @@ public interface PlaceControllerSwagger {
     @ApiResponse(responseCode = "200",
             description = "오프로드 등록 장소 조회 완료",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-            ResponseEntity<APISuccessResponse<RegisteredPlacesResponse>> checkRegisteredPlaces(
+            ResponseEntity<APISuccessResponse<RegisteredPlacesResponse>> getPlaces(
             @RequestParam double currentLatitude,
-            @RequestParam double currentLongitude
-    );
-
-
-    @Operation(summary = "방문하지 않은 장소 조회 API", description = "방문하지 않은 장소 조회 API입니다.")
-    @ApiResponse(
-            responseCode = "200",
-            description = "방문하지 않은 장소 조회 완료",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class))
-
-    )
-    @GetMapping("/places/unvisited")
-    ResponseEntity<APISuccessResponse<UnvisitedPlacesResponse>> getUnvisitedPlacesResponse(
-            @RequestParam double currentLatitude,
-            @RequestParam double currentLongitude
+            @RequestParam double currentLongitude,
+            @RequestParam int limit,
+            @RequestParam Boolean isBounded
     );
 }

--- a/offroad-api/src/main/java/site/offload/api/place/dto/request/RegisteredPlacesRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/request/RegisteredPlacesRequest.java
@@ -2,13 +2,12 @@ package site.offload.api.place.dto.request;
 
 public record RegisteredPlacesRequest(
         double currentLatitude,
-        double currentLongitude,
-        Boolean isVisit
+        double currentLongitude
 ) {
     public static RegisteredPlacesRequest of(
             double currentLatitude,
-            double currentLongitude,
-            Boolean isVisit) {
-        return new RegisteredPlacesRequest(currentLatitude, currentLongitude, isVisit);
+            double currentLongitude
+            ) {
+        return new RegisteredPlacesRequest(currentLatitude, currentLongitude);
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/place/dto/request/UnvisitedPlacesRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/request/UnvisitedPlacesRequest.java
@@ -1,0 +1,12 @@
+package site.offload.api.place.dto.request;
+
+public record UnvisitedPlacesRequest(
+        double currentLatitude,
+        double currentLongitude) {
+    public static UnvisitedPlacesRequest of(
+            double currentLatitude,
+            double currentLongitude
+    ) {
+        return new UnvisitedPlacesRequest(currentLatitude, currentLongitude);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/place/dto/response/UnvisitedPlaceResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/response/UnvisitedPlaceResponse.java
@@ -1,0 +1,29 @@
+package site.offload.api.place.dto.response;
+
+import site.offload.enums.place.PlaceCategory;
+
+public record UnvisitedPlaceResponse(
+        Long id,
+        String name,
+        String address,
+        String shortIntroduction,
+        PlaceCategory placeCategory,
+        double latitude,
+        double longitude,
+        Long visitCount,
+        String categoryImageUrl
+) {
+    public static UnvisitedPlaceResponse of(
+            Long id,
+            String name,
+            String address,
+            String shortIntroduction,
+            PlaceCategory placeCategory,
+            double latitude,
+            double longitude,
+            Long visitCount,
+            String categoryImageUrl
+    ) {
+        return new UnvisitedPlaceResponse(id, name, address, shortIntroduction, placeCategory, latitude, longitude, visitCount, categoryImageUrl);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/place/dto/response/UnvisitedPlacesResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/response/UnvisitedPlacesResponse.java
@@ -1,0 +1,11 @@
+package site.offload.api.place.dto.response;
+
+import java.util.List;
+
+public record UnvisitedPlacesResponse(
+        List<UnvisitedPlaceResponse> places
+) {
+    public static UnvisitedPlacesResponse of(List<UnvisitedPlaceResponse> places) {
+        return new UnvisitedPlacesResponse(places);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/place/service/PlaceService.java
+++ b/offroad-api/src/main/java/site/offload/api/place/service/PlaceService.java
@@ -17,12 +17,24 @@ public class PlaceService {
     private final PlaceRepository placeRepository;
 
     // TODO: change method name
-    public List<PlaceEntity> findPlaces(double currentLatitude, double currentLongitude) {
-        return placeRepository.findTop100ByLatitudeBetweenAndLongitudeBetween(currentLatitude, currentLongitude, PlaceConstants.RANGE_LATITUDE.getRange(), PlaceConstants.RANGE_LONGITUDE.getRange());
+    public List<PlaceEntity> findTopNByCurrentLatitudeAndCurrentLongitude(
+            double currentLatitude,
+            double currentLongitude,
+            int limit
+    ) {
+        return placeRepository.findNearestPlacesByLatitudeAndLongitude(currentLatitude, currentLongitude, limit);
     }
 
-    public List<PlaceEntity> findUnvisitedPlaces(final Long memberId, final double currentLatitude, final double currentLongitude) {
-        return placeRepository.findUnvisitedPlacesByMemberIdAndLocation(memberId, currentLatitude, currentLongitude, PlaceConstants.RANGE_LATITUDE.getRange(), PlaceConstants.RANGE_LONGITUDE.getRange());
+    public List<PlaceEntity> findAllByCurrentLatitudeAndCurrentLongitude(
+            double currentLatitude,
+            double currentLongitude
+    ) {
+        return placeRepository.findAllByCurrentLatitudeAndCurrentLongitude(
+                currentLatitude,
+                currentLongitude,
+                PlaceConstants.RANGE_LATITUDE.getRange(),
+                PlaceConstants.RANGE_LONGITUDE.getRange()
+        );
     }
 
     public PlaceEntity findPlaceById(final Long placeId) {

--- a/offroad-api/src/main/java/site/offload/api/place/service/PlaceService.java
+++ b/offroad-api/src/main/java/site/offload/api/place/service/PlaceService.java
@@ -3,10 +3,8 @@ package site.offload.api.place.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.offload.api.exception.NotFoundException;
-import site.offload.api.place.dto.request.RegisteredPlacesRequest;
 import site.offload.db.place.entity.PlaceEntity;
 import site.offload.db.place.repository.PlaceRepository;
-import site.offload.db.place.repository.VisitedPlaceRepository;
 import site.offload.enums.response.ErrorMessage;
 import site.offload.enums.place.PlaceConstants;
 
@@ -17,15 +15,14 @@ import java.util.List;
 public class PlaceService {
 
     private final PlaceRepository placeRepository;
-    private final VisitedPlaceRepository visitedPlaceRepository;
 
     // TODO: change method name
-    public List<PlaceEntity> findPlaces(RegisteredPlacesRequest registeredPlacesRequest) {
-        return placeRepository.findTop100ByLatitudeBetweenAndLongitudeBetween(registeredPlacesRequest.currentLatitude(), registeredPlacesRequest.currentLongitude(), PlaceConstants.RANGE_LATITUDE.getRange(), PlaceConstants.RANGE_LONGITUDE.getRange());
+    public List<PlaceEntity> findPlaces(double currentLatitude, double currentLongitude) {
+        return placeRepository.findTop100ByLatitudeBetweenAndLongitudeBetween(currentLatitude, currentLongitude, PlaceConstants.RANGE_LATITUDE.getRange(), PlaceConstants.RANGE_LONGITUDE.getRange());
     }
 
-    public Long countVisitedPlace(Long memberId, PlaceEntity findPlaceEntity) {
-        return visitedPlaceRepository.countByMemberEntityIdAndPlaceEntityId(memberId, findPlaceEntity.getId());
+    public List<PlaceEntity> findUnvisitedPlaces(final Long memberId, final double currentLatitude, final double currentLongitude) {
+        return placeRepository.findUnvisitedPlacesByMemberIdAndLocation(memberId, currentLatitude, currentLongitude, PlaceConstants.RANGE_LATITUDE.getRange(), PlaceConstants.RANGE_LONGITUDE.getRange());
     }
 
     public PlaceEntity findPlaceById(final Long placeId) {

--- a/offroad-api/src/main/java/site/offload/api/place/service/VisitedPlaceService.java
+++ b/offroad-api/src/main/java/site/offload/api/place/service/VisitedPlaceService.java
@@ -20,7 +20,11 @@ public class VisitedPlaceService {
         return visitedPlaceRepository.save(visitedPlaceEntity).getId();
     }
 
-    public Long countByMemberAndPlace(MemberEntity memberEntity, PlaceEntity placeEntity) {
+    public Long countByMemberIdAndPlace(Long memberId, PlaceEntity placeEntity) {
+        return visitedPlaceRepository.countByMemberEntityIdAndPlaceEntityId(memberId, placeEntity.getId());
+    }
+
+    public Long countMemberAndPlace(MemberEntity memberEntity, PlaceEntity placeEntity) {
         return visitedPlaceRepository.countByMemberEntityIdAndPlaceEntityId(memberEntity.getId(), placeEntity.getId());
     }
 
@@ -34,5 +38,9 @@ public class VisitedPlaceService {
   
     public Long countByMember(MemberEntity entity) {
         return visitedPlaceRepository.countByMemberEntityId(entity.getId());
+    }
+
+    public Boolean existsByMemberAndPlace(MemberEntity memberEntity, PlaceEntity placeEntity) {
+        return visitedPlaceRepository.existsByMemberEntityIdAndPlaceEntityId(memberEntity.getId(), placeEntity.getId());
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/place/usecase/PlaceUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/place/usecase/PlaceUseCase.java
@@ -4,12 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.offload.api.place.dto.request.RegisteredPlacesRequest;
+import site.offload.api.place.dto.request.UnvisitedPlacesRequest;
 import site.offload.api.place.dto.response.RegisteredPlaceResponse;
 import site.offload.api.place.dto.response.RegisteredPlacesResponse;
+import site.offload.api.place.dto.response.UnvisitedPlaceResponse;
+import site.offload.api.place.dto.response.UnvisitedPlacesResponse;
 import site.offload.api.place.service.PlaceService;
 import site.offload.api.place.service.VisitedPlaceService;
-import site.offload.db.place.entity.PlaceEntity;
 import site.offload.external.aws.S3Service;
+
 
 @Service
 @RequiredArgsConstructor
@@ -21,46 +24,43 @@ public class PlaceUseCase {
 
     @Transactional(readOnly = true)
     public RegisteredPlacesResponse checkRegisteredPlaces(Long memberId, RegisteredPlacesRequest request) {
-        if (request.isVisit()) {
-            return
-                    RegisteredPlacesResponse.of(
-                            visitedPlaceService.findAllByMemberId(memberId)
-                                    .stream().map(
-                                            visitedPlace -> {
-                                                final Long count = placeService.countVisitedPlace(memberId, visitedPlace.getPlaceEntity());
-                                                final PlaceEntity placeEntity = visitedPlace.getPlaceEntity();
-                                                return RegisteredPlaceResponse.of(
-                                                        placeEntity.getId(),
-                                                        placeEntity.getName(),
-                                                        placeEntity.getAddress(),
-                                                        placeEntity.getShortIntroduction(),
-                                                        placeEntity.getPlaceCategory(),
-                                                        placeEntity.getLatitude(),
-                                                        placeEntity.getLongitude(),
-                                                        count,
-                                                        s3Service.getPresignUrl(visitedPlace.getPlaceEntity().getCategoryImageUrl())
-                                                );
-                                            }).toList()
-                    );
-        } else {
-            return RegisteredPlacesResponse.of(
-                    placeService.findPlaces(request).stream().map(
-                            findPlace -> {
-                                Long count = placeService.countVisitedPlace(memberId, findPlace);
-                                return RegisteredPlaceResponse.of(
-                                        findPlace.getId(),
-                                        findPlace.getName(),
-                                        findPlace.getAddress(),
-                                        findPlace.getShortIntroduction(),
-                                        findPlace.getPlaceCategory(),
-                                        findPlace.getLatitude(),
-                                        findPlace.getLongitude(),
-                                        count,
-                                        s3Service.getPresignUrl(findPlace.getCategoryImageUrl())
-                                );
-                            }
-                    ).toList()
+
+        return RegisteredPlacesResponse.of(
+                placeService.findPlaces(request.currentLatitude(), request.currentLongitude())
+                        .stream()
+                        .map(findPlace -> {
+                            Long count = visitedPlaceService.countByMemberIdAndPlace(memberId, findPlace);
+                            return RegisteredPlaceResponse.of(
+                                    findPlace.getId(),
+                                    findPlace.getName(),
+                                    findPlace.getAddress(),
+                                    findPlace.getShortIntroduction(),
+                                    findPlace.getPlaceCategory(),
+                                    findPlace.getLatitude(),
+                                    findPlace.getLongitude(),
+                                    count,
+                                    s3Service.getPresignUrl(findPlace.getCategoryImageUrl())
+                            );
+                        }).toList()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public UnvisitedPlacesResponse checkUnvisitedPlaces(Long memberId, UnvisitedPlacesRequest request) {
+            return UnvisitedPlacesResponse.of(
+                    placeService.findUnvisitedPlaces(memberId, request.currentLatitude(), request.currentLongitude())
+                            .stream()
+                            .map(findPlace -> UnvisitedPlaceResponse.of(
+                                    findPlace.getId(),
+                                    findPlace.getName(),
+                                    findPlace.getAddress(),
+                                    findPlace.getShortIntroduction(),
+                                    findPlace.getPlaceCategory(),
+                                    findPlace.getLatitude(),
+                                    findPlace.getLongitude(),
+                                    0L,
+                                    s3Service.getPresignUrl(findPlace.getCategoryImageUrl())
+                            )).toList()
             );
-        }
     }
 }

--- a/offroad-api/src/main/resources/application-local.yaml
+++ b/offroad-api/src/main/resources/application-local.yaml
@@ -5,7 +5,7 @@ spring:
       on-profile: local
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:tcp://localhost/~/offroad
+    url: jdbc:h2:tcp://localhost/~/testdb
     username: sa
     password:
   jpa:

--- a/offroad-api/src/test/java/site/offload/api/questReward/repository/QuestRewardRepositoryTest.java
+++ b/offroad-api/src/test/java/site/offload/api/questReward/repository/QuestRewardRepositoryTest.java
@@ -49,8 +49,6 @@ public class QuestRewardRepositoryTest {
                 .toList();
 
         //then
-
-        System.out.println("emblems = " + emblems);
         Assertions.assertThat(emblems).contains(questRewardEntity1.getRewardList().getEmblemCode());
         Assertions.assertThat(emblems).contains(questRewardEntity4.getRewardList().getEmblemCode());
         Assertions.assertThat(emblems.size()).isEqualTo(3);

--- a/offroad-db/build.gradle
+++ b/offroad-db/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     implementation project(path: ':offroad-enum')
 }

--- a/offroad-db/src/main/java/site/offload/db/place/repository/PlaceRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/place/repository/PlaceRepository.java
@@ -17,4 +17,16 @@ public interface PlaceRepository extends JpaRepository<PlaceEntity, Long> {
     List<PlaceEntity> findTop100ByLatitudeBetweenAndLongitudeBetween(double minLatitude, double maxLatitude, double minLongitude, double MaxLongitude);
 
     Optional<PlaceEntity> findByCouponAuthCode(String couponAuthCode);
+
+    @Query("SELECT p FROM PlaceEntity p " +
+            "WHERE p.id NOT IN (SELECT vp.placeEntity.id FROM VisitedPlaceEntity vp WHERE vp.memberEntity.id = :memberId) " +
+            "AND p.latitude BETWEEN :latitude - :latitudeBias AND :latitude + :latitudeBias " +
+            "AND p.longitude BETWEEN :longitude - :longitudeBias AND :longitude + :longitudeBias")
+    List<PlaceEntity> findUnvisitedPlacesByMemberIdAndLocation(
+            @Param("memberId") Long memberId,
+            @Param("latitude") double latitude,
+            @Param("longitude") double longitude,
+            @Param("latitudeBias") double latitudeBias,
+            @Param("longitudeBias") double longitudeBias
+    );
 }

--- a/offroad-db/src/main/java/site/offload/db/place/repository/PlaceRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/place/repository/PlaceRepository.java
@@ -14,19 +14,18 @@ public interface PlaceRepository extends JpaRepository<PlaceEntity, Long> {
     @Query("select p from PlaceEntity p where p.latitude >= :currentLatitude - :rangeLatitude and p.latitude <= :currentLatitude + :rangeLatitude and p.longitude >= :currentLongitude - :rangeLongitude and p.longitude <= :currentLongitude + :rangeLongitude")
     List<PlaceEntity> findAllByCurrentLatitudeAndCurrentLongitude(@Param("currentLatitude") double currentLatitude, @Param("currentLongitude") double currentLongitude, @Param("rangeLatitude") double rangeLatitude, @Param("rangeLongitude") double rangeLongitude);
 
-    List<PlaceEntity> findTop100ByLatitudeBetweenAndLongitudeBetween(double minLatitude, double maxLatitude, double minLongitude, double MaxLongitude);
-
     Optional<PlaceEntity> findByCouponAuthCode(String couponAuthCode);
 
-    @Query("SELECT p FROM PlaceEntity p " +
-            "WHERE p.id NOT IN (SELECT vp.placeEntity.id FROM VisitedPlaceEntity vp WHERE vp.memberEntity.id = :memberId) " +
-            "AND p.latitude BETWEEN :latitude - :latitudeBias AND :latitude + :latitudeBias " +
-            "AND p.longitude BETWEEN :longitude - :longitudeBias AND :longitude + :longitudeBias")
-    List<PlaceEntity> findUnvisitedPlacesByMemberIdAndLocation(
-            @Param("memberId") Long memberId,
+    @Query(value = "SELECT id, name, latitude, longitude, " +
+            "ST_Distance_Sphere(POINT(:longitude, :latitude), POINT(longitude, latitude)) AS distance " +
+            "FROM Place " +
+            "ORDER BY distance ASC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<PlaceEntity> findNearestPlacesByLatitudeAndLongitude(
             @Param("latitude") double latitude,
             @Param("longitude") double longitude,
-            @Param("latitudeBias") double latitudeBias,
-            @Param("longitudeBias") double longitudeBias
+            @Param("limit") int limit
     );
+
 }

--- a/offroad-db/src/main/java/site/offload/db/place/repository/VisitedPlaceRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/place/repository/VisitedPlaceRepository.java
@@ -14,4 +14,6 @@ public interface VisitedPlaceRepository extends JpaRepository<VisitedPlaceEntity
     void deleteAllByMemberEntityId(long memberId);
 
     List<VisitedPlaceEntity> findTop100ByMemberEntityId(long memberId);
+
+    Boolean existsByMemberEntityIdAndPlaceEntityId(Long memberId, Long placeId);
 }

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -30,6 +30,7 @@ public enum SuccessMessage {
     GET_EMBLEMS_SUCCESS("칭호 조회 완료"),
     GET_MOTIONS_SUCCESS("캐릭터 모션 목록 조회 성공"),
     GET_CHARACTER_DETAIL_SUCCESS("캐릭터 상세 정보 조회 성공"),
-    GET_USER_INFO_SUCCESS("사용자 정보 조회 성공");
+    GET_USER_INFO_SUCCESS("사용자 정보 조회 성공"),
+    CHECK_UNVISITED_PLACES_SUCCESS("미방문 장소 목록 조회 성공"),;
     private final String message;
 }


### PR DESCRIPTION
## 변경사항
-  요구 사항에 맞춰서 API를 수정했습니다. 기존 장소 조회 API는 스펙을 유지하고, 안가본곳을 조회하는 API를 별도로 구현했습니다.
- 장소는 기본적으로 가까운 순으로 조회하고, Query String으로 isBounded를 받아, True인 경우 기존 API 동작 방식인 주변으ㅢ 장소를 조회하는 형태로 구현.
## 고려사항

## Comment
- db module에서 test를 짤려고 헀는데 Spring Bean 등록이 안되네요 ..! 나중에 해결해보겠습니다.

## Test

## 질문사항

