### PR TITLE
fix: 쿠폰 획득 및 목록 조회 api 수정

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/coupon/dto/AvailableCouponResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/dto/AvailableCouponResponse.java
@@ -1,9 +1,9 @@
 package site.offload.api.coupon.dto;
 
 public record AvailableCouponResponse(long id, String name, String couponImageUrl, String description,
-                                      boolean isNewGained) {
+                                      boolean isNewGained, long placeId) {
 
-    public static AvailableCouponResponse of(long id, String name, String couponImageUrl, String description, boolean isNewGained) {
-        return new AvailableCouponResponse(id, name, couponImageUrl, description, isNewGained);
+    public static AvailableCouponResponse of(long id, String name, String couponImageUrl, String description, boolean isNewGained, long placeId) {
+        return new AvailableCouponResponse(id, name, couponImageUrl, description, isNewGained, placeId);
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/coupon/usecase/CouponListUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/usecase/CouponListUseCase.java
@@ -42,7 +42,8 @@ public class CouponListUseCase {
                                         couponEntity.getName(),
                                         couponEntity.getCouponImageUrl(),
                                         couponEntity.getDescription(),
-                                        isNewGained)
+                                        isNewGained,
+                                        gainedCouponEntity.getAcquisitionPlaceId())
                         );
                     }
                 }

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/AuthAdventureUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/AuthAdventureUseCase.java
@@ -249,7 +249,7 @@ public class AuthAdventureUseCase {
                 if (questEntity.isQuestSamePlace()) {
                     handleSamePlaceReward(memberEntity, couponEntity, placeEntity, couponCode);
                 } else {
-                    handleNotSamePlaceReward(memberEntity, couponEntity);
+                    handleNotSamePlaceReward(memberEntity, couponEntity, placeEntity);
                 }
             }
         });
@@ -258,26 +258,27 @@ public class AuthAdventureUseCase {
 
     private void handleSamePlaceReward(final MemberEntity memberEntity, final CouponEntity couponEntity, final PlaceEntity placeEntity, final String couponCode) {
         if (SAME_PLACE_TICKET_COUPON_LIST.contains(couponCode) && PlaceCategory.isPlaceCategoryForTicketCoupon(placeEntity.getPlaceCategory())) {
-            saveGainedCoupon(memberEntity, couponEntity, placeEntity.getId());
+            saveGainedCoupon(placeEntity.getId(), memberEntity, couponEntity, placeEntity.getId());
         }
 
         if (SAME_PLACE_FIXED_DISCOUNT_COUPON_LIST.contains(couponCode) && PlaceCategory.isPlaceCategoryForFixedDiscountCoupon(placeEntity.getPlaceCategory())) {
-            saveGainedCoupon(memberEntity, couponEntity, placeEntity.getId());
+            saveGainedCoupon(placeEntity.getId(), memberEntity, couponEntity, placeEntity.getId());
         }
     }
 
-    private void handleNotSamePlaceReward(final MemberEntity memberEntity, final CouponEntity couponEntity) {
+    private void handleNotSamePlaceReward(final MemberEntity memberEntity, final CouponEntity couponEntity, final PlaceEntity placeEntity) {
         if (!gainedCouponService.isExistByMemberEntityIdAndCouponId(memberEntity.getId(), couponEntity.getId())) {
-            saveGainedCoupon(memberEntity, couponEntity, null);
+            saveGainedCoupon(placeEntity.getId(), memberEntity, couponEntity, null);
         }
     }
 
-    private void saveGainedCoupon(final MemberEntity memberEntity, final CouponEntity couponEntity, final Long samePlaceRewardPlaceId) {
+    private void saveGainedCoupon(final Long acquisitionPlaceId, final MemberEntity memberEntity, final CouponEntity couponEntity, final Long samePlaceRewardPlaceId) {
         if (!gainedCouponService.isExistByMemberEntityIdAndCouponId(memberEntity.getId(), couponEntity.getId())) {
             gainedCouponService.save(GainedCouponEntity.builder()
                     .memberEntity(memberEntity)
                     .couponEntity(couponEntity)
                     .samePlaceRewardPlaceId(samePlaceRewardPlaceId)
+                    .acquisitionPlaceId(acquisitionPlaceId)
                     .build());
         }
     }

--- a/offroad-db/src/main/java/site/offload/db/coupon/entity/GainedCouponEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/coupon/entity/GainedCouponEntity.java
@@ -37,8 +37,11 @@ public class GainedCouponEntity extends BaseTimeEntity {
 
     private boolean isNewGained = true;
 
+    private Long acquisitionPlaceId;
+
     @Builder
-    public GainedCouponEntity(MemberEntity memberEntity, CouponEntity couponEntity, Long samePlaceRewardPlaceId) {
+    public GainedCouponEntity(Long acquisitionPlaceId, MemberEntity memberEntity, CouponEntity couponEntity, Long samePlaceRewardPlaceId) {
+        this.acquisitionPlaceId = acquisitionPlaceId;
         this.memberEntity = memberEntity;
         this.couponEntity = couponEntity;
         this.samePlaceRewardPlaceId = samePlaceRewardPlaceId;


### PR DESCRIPTION
## 변경사항
- GainedCouponEntity에 어느 장소에서 획득했는지에 대한 정보인 acquisitionPlaceId 필드 추가
- 퀘스트 완료 후 보상으로 쿠폰 획득 시 acquisitionPlaceId도 같이 저장
- 쿠폰 리스트 조회 API에서 응답값에 해당 쿠폰 획득 장소의 id인 placeId 값 추가
## 고려사항
- 쿠폰 사용 api에서 요청으로 placeId를 포함시키기 위해 변경사항 부분을 수정했습니다
## Comment

## Test

## 질문사항

