### PR TITLE
[refactor] : 캐릭터 아이디 철자 수정 및 약관 동의 여부 저장

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
@@ -89,12 +89,12 @@ public class MemberController implements MemberControllerSwagger {
         return APISuccessResponse.of(HttpStatus.ACCEPTED.value(), SuccessMessage.SOFT_DELETE_MEMBER_SUCCESS.getMessage(), null);
     }
   
-    @PatchMapping("/marketing")
-    public ResponseEntity<APISuccessResponse<Void>> agreeMarketing(
-            @RequestBody MarketingAgreeRequest marketingAgreeRequest
+    @PatchMapping("/agree")
+    public ResponseEntity<APISuccessResponse<Void>> agreeTerms(
+            @RequestBody TermsAgreeRequest termsAgreeRequest
     ) {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
-        memberUseCase.updateAgreeMarketing(memberId, marketingAgreeRequest.marketing());
-        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.CHECK_AGREE_MARKETING_SUCCESS.getMessage(), null);
+        memberUseCase.updateAgreeTerms(memberId, termsAgreeRequest.marketing());
+        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.CHECK_AGREE_TERMS_SUCCESS.getMessage(), null);
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
@@ -50,8 +50,8 @@ public interface MemberControllerSwagger {
 
     @Operation(summary = "마케팅 수신 여부 API", description = "마케팅 수신 여부 API")
     @ApiResponse(responseCode = "200", description = "마케팅 수신 여부 업데이트 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<Void>> agreeMarketing(
-            @RequestBody MarketingAgreeRequest marketingAgreeRequest
+    public ResponseEntity<APISuccessResponse<Void>> agreeTerms(
+            @RequestBody TermsAgreeRequest termsAgreeRequest
     );
 }
 

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/TermsAgreeRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/TermsAgreeRequest.java
@@ -1,6 +1,6 @@
 package site.offload.api.member.dto.request;
 
-public record MarketingAgreeRequest(
+public record TermsAgreeRequest(
         boolean marketing
 ) {
 }

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharacterResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharacterResponse.java
@@ -1,7 +1,7 @@
 package site.offload.api.member.dto.response;
 
 public record GainedCharacterResponse(
-        Integer CharacterId,
+        Integer characterId,
         String characterName,
         String characterThumbnailImageUrl,
         String characterMainColorCode,

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -24,7 +24,6 @@ import site.offload.cache.member.service.MemberStatusCacheService;
 import site.offload.db.character.entity.CharacterEntity;
 import site.offload.db.character.entity.GainedCharacterEntity;
 import site.offload.db.charactermotion.entity.CharacterMotionEntity;
-import site.offload.db.charactermotion.entity.GainedCharacterMotionEntity;
 import site.offload.db.member.embeddable.Birthday;
 import site.offload.db.member.entity.MemberEntity;
 import site.offload.enums.member.MemberStatus;
@@ -184,9 +183,9 @@ public class MemberUseCase {
         MemberDeleteLoggingUtil.loggingSoftDeleteMember(findMember);
     }
 
-    public void updateAgreeMarketing(Long memberId, boolean isAgreeMarketing) {
+    public void updateAgreeTerms(Long memberId, boolean isAgreeMarketing) {
         MemberEntity findMemberEntity = memberService.findById(memberId);
-        findMemberEntity.updateAgreeMarketing(isAgreeMarketing);
+        findMemberEntity.updateAgreeTerms(isAgreeMarketing);
     }
 }
 

--- a/offroad-api/src/main/resources/application-local.yaml
+++ b/offroad-api/src/main/resources/application-local.yaml
@@ -5,7 +5,7 @@ spring:
       on-profile: local
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:tcp://localhost/~/testdb
+    url: jdbc:h2:tcp://localhost/~/offroad
     username: sa
     password:
   jpa:

--- a/offroad-api/src/test/java/site/offload/api/member/usecase/MemberUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/member/usecase/MemberUseCaseTest.java
@@ -80,7 +80,7 @@ class MemberUseCaseTest {
         MemberEntity memberEntity = createMemberEntity("example sub", "example@offroad.com", SocialPlatform.GOOGLE, "이름");
         BDDMockito.given(memberService.findById(any())).willReturn(memberEntity);
         //when
-        memberUseCase.updateAgreeMarketing(1L, false);
+        memberUseCase.updateAgreeTerms(1L, false);
         //then
         Assertions.assertThat(memberEntity.isAgreeMarketing()).isEqualTo(false);
     }

--- a/offroad-db/src/main/java/site/offload/db/member/entity/MemberEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/member/entity/MemberEntity.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import site.offload.db.BaseTimeEntity;
 import site.offload.db.member.embeddable.Birthday;
 import site.offload.enums.emblem.Emblem;
@@ -70,7 +71,17 @@ public class MemberEntity extends BaseTimeEntity {
 
     private LocalDateTime inactiveSince;
 
+    @ColumnDefault("false")
     private boolean isAgreeMarketing;
+
+    @ColumnDefault("false")
+    private boolean isAgreeService;
+
+    @ColumnDefault("false")
+    private boolean isAgreeInfo;
+
+    @ColumnDefault("false")
+    private boolean isAgreeLocation;
 
 
     @Builder
@@ -105,7 +116,10 @@ public class MemberEntity extends BaseTimeEntity {
         }
     }
 
-    public void updateAgreeMarketing(boolean isAgreeMarketing) {
+    public void updateAgreeTerms(boolean isAgreeMarketing) {
         this.isAgreeMarketing = isAgreeMarketing;
+        this.isAgreeService = true;
+        this.isAgreeInfo = true;
+        this.isAgreeLocation = true;
     }
 }

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -11,7 +11,7 @@ public enum SuccessMessage {
     SIGN_OUT_SUCCESS("로그아웃 성공"),
     DELETE_TEST_MEMBER_SUCCESS("테스트 회원 삭제 성공"),
     SOFT_DELETE_MEMBER_SUCCESS("회원 탈퇴 성공"),
-    CHECK_AGREE_MARKETING_SUCCESS("마케팅 정보 수신 여부 확인 완료"),
+    CHECK_AGREE_TERMS_SUCCESS("약관 동의 여부 확인 완료"),
     ACCESS_TOKEN_REFRESH_SUCCESS("Access Token 재발급 성공"),
     MEMBER_ADVENTURE_INFORMATION_SUCCESS("모험 정보 조회 성공"),
     CHECK_REGISTERED_PLACES_SUCCESS("장소 리스트 정보 조회 성공"),


### PR DESCRIPTION
## 변경사항

### 획득 캐릭터 응답 값 수정

* 획득 캐릭터 응답 값 중 CharacterId의 앞 부분을 소문자로 수정했습니다

### 약관 동의 여부 저장

* 약관 동의 여부를 저장할 수 있도록 MemberEntity에 필드를 추가했습니다.