### PR TITLE
[fix] : 캐릭터 조회 API에 대표 캐릭터 ID 추가

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharactersResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharactersResponse.java
@@ -4,9 +4,10 @@ import java.util.List;
 
 public record GainedCharactersResponse(
         List<GainedCharacterResponse> gainedCharacters,
-        List<GainedCharacterResponse> notGainedCharacters
+        List<GainedCharacterResponse> notGainedCharacters,
+        Integer representativeCharacterId
 ) {
-    public static GainedCharactersResponse of(List<GainedCharacterResponse> gainedCharacters, List<GainedCharacterResponse> notGainedCharacters) {
-        return new GainedCharactersResponse(gainedCharacters, notGainedCharacters);
+    public static GainedCharactersResponse of(List<GainedCharacterResponse> gainedCharacters, List<GainedCharacterResponse> notGainedCharacters, Integer representativeCharacterId) {
+        return new GainedCharactersResponse(gainedCharacters, notGainedCharacters, representativeCharacterId);
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -111,8 +111,9 @@ public class MemberUseCase {
     @Transactional(readOnly = true)
     public GainedCharactersResponse getGainedCharacters(Long memberId) {
         List<CharacterEntity> characterEntities = characterService.findAll();
-
         MemberEntity memberEntity = memberService.findById(memberId);
+        CharacterEntity currentCharacterEntity = characterService.findByName(memberEntity.getCurrentCharacterName());
+
 
         List<GainedCharacterResponse> gainedCharacters = characterEntities.stream()
                 .filter(characterEntity -> gainedCharacterService.isExistsGainedCharacterByMemberAndCharacter(memberEntity, characterEntity))
@@ -129,7 +130,7 @@ public class MemberUseCase {
                 .map(characterEntity -> GainedCharacterResponse.of(characterEntity.getId(), characterEntity.getName(), s3Service.getPresignUrl(characterEntity.getNotGainedCharacterThumbnailImageUrl()), characterEntity.getCharacterMainColorCode(), characterEntity.getCharacterSubColorCode(), false))
                 .collect(Collectors.toList());
 
-        return GainedCharactersResponse.of(gainedCharacters, notGainedCharacters);
+        return GainedCharactersResponse.of(gainedCharacters, notGainedCharacters, currentCharacterEntity.getId());
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 변경사항

### 캐릭터 조회 API에 대표 캐릭터 ID 추가

* 대표 캐릭터에 왕관 표시를 해야하는 이슈가 있었는데, 대표 캐릭터의 아이디를 따로 넘기는 부분이 존재하지 않다는 클라이언트 분들의 말씀이 있어서 이에 대해서 수정하였습니다.
