### PR TITLE
fix: 퀘스트 목록 조회 API 수정

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/quest/service/QuestService.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/service/QuestService.java
@@ -46,4 +46,7 @@ public class QuestService {
         );
     }
 
+    public List<QuestEntity> findAll() {
+        return questRepository.findAll();
+    }
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/usecase/QuestUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/usecase/QuestUseCase.java
@@ -1,6 +1,7 @@
 package site.offload.api.quest.usecase;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.offload.api.member.service.MemberService;
@@ -23,6 +24,7 @@ import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class QuestUseCase {
 
     private final QuestService questService;
@@ -81,19 +83,22 @@ public class QuestUseCase {
         final List<QuestEntity> completedQuestList = completeQuestService.findAllByMemberId(memberId)
                 .stream()
                 .map(CompleteQuestEntity::getQuestEntity).toList();
-
         final List<Integer> completeQuestIdList = completedQuestList.stream()
                 .map(QuestEntity::getId)
                 .toList();
 
-        final List<QuestEntity> notCompletedQuestList = questService.findByIdNotIn(completeQuestIdList)
-                .stream()
-                .sorted(Comparator.comparing(QuestEntity::getId))
-                .toList();
+        List<QuestEntity> notCompletedQuestList;
+        if (completeQuestIdList.isEmpty()) {
+            notCompletedQuestList = questService.findAll();
+        } else {
+            notCompletedQuestList = questService.findByIdNotIn(completeQuestIdList)
+                    .stream()
+                    .sorted(Comparator.comparing(QuestEntity::getId))
+                    .toList();
+        }
 
         final List<QuestEntity> allQuests = new ArrayList<>(notCompletedQuestList);
         allQuests.addAll(completedQuestList);
-
         return allQuests.stream().map(
                 questEntity -> {
                     int currentClearCount = 0;

--- a/offroad-api/src/test/java/site/offload/api/quest/service/QuestServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/quest/service/QuestServiceTest.java
@@ -62,4 +62,22 @@ class QuestServiceTest {
         //then
         assertThat(expectedList).containsExactly(questEntity1, questEntity2);
     }
+
+    @Test
+    @DisplayName("모든 퀘스트 목록을 조회할 수 있다.")
+    void findAll() {
+
+        //given
+        QuestEntity questEntity1 = createQuest(false, "test", PlaceCategory.CAFFE, PlaceArea.NONE, 1);
+        QuestEntity questEntity2 = createQuest(false, "test", PlaceCategory.NONE, PlaceArea.AREA1, 1);
+
+        given(questRepository.findAll()).willReturn(List.of(questEntity1, questEntity2));
+
+        //when
+        List<QuestEntity> expectedList = questService.findAll();
+
+        //then
+        assertThat(expectedList).containsExactly(questEntity1, questEntity2);
+
+    }
 }


### PR DESCRIPTION
## 변경사항
- QuestUseCase에서 전체 퀘스트 목록을 조회할 때, 진행 중인 퀘스트가 있는지 없는지에 따라 if문 분기처리를 추가했습니다.
## 고려사항
- 사용자가 진행하는 퀘스트가 전혀 없을 경우, findByNotIn() 파라미터에 들어가는 Collection이 비어있게 되는데, 빈 컬렉션이 들어가면 모든 값을 제외하고 쿼리를 해서 반환 값이 비어있었습니다.
- 따라서 컬렉션이 비어있는 경우, 직접 모든 퀘스트 목록을 가져오도록 코드를 수정했습니다. 
## Comment
- 로컬 환경에서 테스트 해봤습니다.
## Test
- QuestService의 findAll() 코드에 대해서 테스트코드 추가했습니다.
## 질문사항

