### PR TITLE
refactor: API Swagger 응답 데이터 정보 추가

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/auth/jwt/TokenResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/auth/jwt/TokenResponse.java
@@ -1,7 +1,11 @@
 package site.offload.api.auth.jwt;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record TokenResponse(
+        @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIsImV4cCI6MTYzNjMwNjQwMH0.7")
         String accessToken,
+        @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIsImV4cCI6MTYzNjMwNjQwMH0.7")
         String refreshToken
 ) {
     public static TokenResponse of(String accessToken, String refreshToken) {

--- a/offroad-api/src/main/java/site/offload/api/character/controller/CharacterControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/character/controller/CharacterControllerSwagger.java
@@ -4,22 +4,21 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import site.offload.api.character.dto.response.CharacterDetailResponse;
 import site.offload.api.character.dto.response.StartCharactersResponse;
 import site.offload.api.response.APISuccessResponse;
 
+
+@Tag(name = "Character API", description = "캐릭터 관련 API")
 public interface CharacterControllerSwagger {
 
     @Operation(summary = "캐릭터 조회 API", description = "캐릭터 목록 조회 API")
-    @ApiResponse(responseCode = "200",
-            description = "캐릭터 목록 조회 성공",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "캐릭터 목록 조회 성공")
     ResponseEntity<APISuccessResponse<StartCharactersResponse>> getStartCharacters();
 
     @Operation(summary = "캐릭터 상세 목록 조회 API", description = "캐릭터 상세 목록 조회 API")
-    @ApiResponse(responseCode = "200",
-            description = "캐릭터 상세 목록 조회 성공",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "캐릭터 상세 목록 조회 성공")
     ResponseEntity<APISuccessResponse<CharacterDetailResponse>> getCharacterDetail(Integer characterId);
 }

--- a/offroad-api/src/main/java/site/offload/api/character/dto/response/CharacterDetailResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/character/dto/response/CharacterDetailResponse.java
@@ -1,16 +1,25 @@
 package site.offload.api.character.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record CharacterDetailResponse(
+        @Schema(description = "캐릭터 ID", example = "1")
         Integer characterId,
+        @Schema(description = "캐릭터 이름", example = "캐릭터 이름")
         String characterName,
+        @Schema(description = "캐릭터 베이스 이미지 URL", example = "https://character-base-image-url.com")
         String characterBaseImageUrl,
+        @Schema(description = "캐릭터 아이콘 이미지 URL", example = "https://character-icon-image-url.com")
         String characterIconImageUrl,
+        @Schema(description = "캐릭터 설명", example = "캐릭터 설명")
         String characterDescription,
+        @Schema(description = "캐릭터 요약 설명", example = "캐릭터 요약 설명")
         String characterSummaryDescription,
+        @Schema(description = "캐릭터 메인 색상 코드", example = "#FFFFFF")
         String characterMainColorCode,
+        @Schema(description = "캐릭터 서브 색상 코드", example = "#FFFFFF")
         String characterSubColorCode
 ) {
     public static CharacterDetailResponse of(Integer characterId, String characterName, String characterBaseImageUrl, String characterIconImageUrl, String characterDescription, String characterSummaryDescription, String characterMainColorCode, String characterSubColorCode) {

--- a/offroad-api/src/main/java/site/offload/api/character/dto/response/StartCharacterResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/character/dto/response/StartCharacterResponse.java
@@ -1,10 +1,21 @@
 package site.offload.api.character.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record StartCharacterResponse(Integer id, String description, String characterBaseImageUrl, String characterCode,
-                                     String name) {
+public record StartCharacterResponse(
+        @Schema(description = "캐릭터 ID", example = "1")
+        Integer id,
+        @Schema(description = "캐릭터 설명", example = "테스트 캐릭터")
+        String description,
+        @Schema(description = "캐릭터 이미지 URL", example = "https://test.com/test.jpg")
+        String characterBaseImageUrl,
+        @Schema(description = "캐릭터 코드", example = "CHAR001")
+        String characterCode,
+        @Schema(description = "캐릭터 이름", example = "테스트 캐릭터")
+        String name
+) {
 
     public static StartCharacterResponse of(Integer id, String description, String characterBaseImageUrl, String characterCode, String name) {
         return StartCharacterResponse.builder()

--- a/offroad-api/src/main/java/site/offload/api/character/dto/response/StartCharactersResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/character/dto/response/StartCharactersResponse.java
@@ -1,9 +1,14 @@
 package site.offload.api.character.dto.response;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
-public record StartCharactersResponse(List<StartCharacterResponse> characters) {
+public record StartCharactersResponse(
+        @Schema(description = "시작 캐릭터 목록")
+        List<StartCharacterResponse> characters
+) {
     public static StartCharactersResponse of(List<StartCharacterResponse> characters) {
         return new StartCharactersResponse(characters);
     }

--- a/offroad-api/src/main/java/site/offload/api/charactermotion/controller/CharacterMotionControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/charactermotion/controller/CharacterMotionControllerSwagger.java
@@ -1,19 +1,16 @@
 package site.offload.api.charactermotion.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import site.offload.api.character.dto.response.CharacterDetailResponse;
 import site.offload.api.charactermotion.dto.CharacterMotionsResponse;
 import site.offload.api.response.APISuccessResponse;
 
+@Tag(name = "CharacterMotion API", description = "캐릭터 모션 API")
 public interface CharacterMotionControllerSwagger {
 
     @Operation(summary = "캐릭터 모션 목록 조회 API", description = "캐릭터 모션 목록 조회 API")
-    @ApiResponse(responseCode = "200",
-            description = "캐릭터 모션 목록 조회 성공",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<CharacterMotionsResponse>> getMotions(Integer characterId);
+    @ApiResponse(responseCode = "200", description = "캐릭터 모션 목록 조회 성공")
+    ResponseEntity<APISuccessResponse<CharacterMotionsResponse>> getMotions(Integer characterId);
 }

--- a/offroad-api/src/main/java/site/offload/api/charactermotion/dto/CharacterMotionResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/charactermotion/dto/CharacterMotionResponse.java
@@ -1,8 +1,13 @@
 package site.offload.api.charactermotion.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record CharacterMotionResponse(
+        @Schema(description = "캐릭터 모션 카테고리", example = "CAFE")
         String category,
+        @Schema(description = "캐릭터 모션 이미지 URL", example = "https://offload.site/character-motion/idle.png")
         String characterMotionImageUrl,
+        @Schema(description = "신규 획득 여부", example = "true")
         boolean isNewGained
 ) {
     public static CharacterMotionResponse of(String category, String characterMotionImageUrl, boolean isNewGained) {

--- a/offroad-api/src/main/java/site/offload/api/charactermotion/dto/CharacterMotionsResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/charactermotion/dto/CharacterMotionsResponse.java
@@ -1,9 +1,13 @@
 package site.offload.api.charactermotion.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record CharacterMotionsResponse(
+        @Schema(description = "획득한 캐릭터 모션 목록")
         List<CharacterMotionResponse> gainedCharacterMotions,
+        @Schema(description = "획득하지 못한 캐릭터 모션 목록")
         List<CharacterMotionResponse> notGainedCharacterMotions
 ) {
     public static CharacterMotionsResponse of(List<CharacterMotionResponse> gainedCharacterMotions, List<CharacterMotionResponse> notGainedCharacterMotions) {

--- a/offroad-api/src/main/java/site/offload/api/config/SwaggerConfig.java
+++ b/offroad-api/src/main/java/site/offload/api/config/SwaggerConfig.java
@@ -9,6 +9,17 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
     //JWT 사용하지 않는 경우
+
+    private static final String SWAGGER_DESCRIPTION = """
+    Offroad API Docs
+    
+    인증/인가가 필요한 API에는
+    Header에 Authorization: Bearer {access_token}을 추가해주세요.
+    그럼에도 동작하지 않는 경우, -> 서버에게 문의해주세요.
+    
+    500 에러가 발생할 경우, 서버에 문제가 있을 수 있습니다. -> 서버에게 문의해주세요.
+    
+    """;
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
@@ -18,8 +29,8 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-                .title("Offroad API Test") // API의 제목
-                .description("Offroad API Test Swagger UI") // API에 대한 설명
+                .title("Offroad API Swagger") // API의 제목
+                .description(SWAGGER_DESCRIPTION) // API에 대한 설명
                 .version("v1"); // API의 버전
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/coupon/controller/CouponControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/controller/CouponControllerSwagger.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,13 +16,14 @@ import site.offload.api.coupon.dto.CouponListResponse;
 import site.offload.api.response.APISuccessResponse;
 import site.offload.enums.response.SuccessMessage;
 
+@Tag(name = "Coupon API", description = "쿠폰 관련 API")
 public interface CouponControllerSwagger {
 
     @Operation(summary = "획득 쿠폰 목록 조회 API", description = "사용한 쿠폰, 사용된 쿠폰 반환하는 API")
-    @ApiResponse(responseCode = "200", description = "획득 쿠폰 조회 요청 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "획득 쿠폰 조회 요청 성공")
     ResponseEntity<APISuccessResponse<CouponListResponse>> getCouponList();
 
     @Operation(summary = "쿠폰 적용 API", description = "쿠폰 적용 API")
-    @ApiResponse(responseCode = "200", description = "쿠폰 적용 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "쿠폰 적용 성공")
     public ResponseEntity<APISuccessResponse<CouponApplyResponse>> useCoupon(CouponApplyRequest request);
 }

--- a/offroad-api/src/main/java/site/offload/api/coupon/dto/AvailableCouponResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/dto/AvailableCouponResponse.java
@@ -1,7 +1,22 @@
 package site.offload.api.coupon.dto;
 
-public record AvailableCouponResponse(long id, String name, String couponImageUrl, String description,
-                                      boolean isNewGained, long placeId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AvailableCouponResponse(
+        @Schema(description = "쿠폰 ID", example = "1")
+
+        long id,
+        @Schema(description = "쿠폰 이름", example = "쿠폰 이름")
+        String name,
+        @Schema(description = "쿠폰 이미지 URL", example = "https://www.google.com")
+        String couponImageUrl,
+        @Schema(description = "쿠폰 설명", example = "쿠폰 설명")
+        String description,
+        @Schema(description = "신규 획득 여부", example = "true")
+        boolean isNewGained,
+        @Schema(description = "장소 ID", example = "1")
+        long placeId
+) {
 
     public static AvailableCouponResponse of(long id, String name, String couponImageUrl, String description, boolean isNewGained, long placeId) {
         return new AvailableCouponResponse(id, name, couponImageUrl, description, isNewGained, placeId);

--- a/offroad-api/src/main/java/site/offload/api/coupon/dto/CouponApplyRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/dto/CouponApplyRequest.java
@@ -1,4 +1,12 @@
 package site.offload.api.coupon.dto;
 
-public record CouponApplyRequest(String code, long couponId, long placeId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CouponApplyRequest(
+        @Schema(description = "쿠폰 코드", example = "couponCode")
+        String code,
+        @Schema(description = "쿠폰 ID", example = "1")
+        long couponId,
+        @Schema(description = "장소 ID", example = "1")
+        long placeId) {
 }

--- a/offroad-api/src/main/java/site/offload/api/coupon/dto/CouponApplyResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/dto/CouponApplyResponse.java
@@ -1,6 +1,11 @@
 package site.offload.api.coupon.dto;
 
-public record CouponApplyResponse(boolean success) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CouponApplyResponse(
+        @Schema(description = "쿠폰 적용 성공 여부", example = "true")
+        boolean success
+) {
 
     public static CouponApplyResponse of(boolean success) {
         return new CouponApplyResponse(success);

--- a/offroad-api/src/main/java/site/offload/api/coupon/dto/CouponListResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/dto/CouponListResponse.java
@@ -1,8 +1,15 @@
 package site.offload.api.coupon.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
-public record CouponListResponse(List<AvailableCouponResponse> availableCoupons, List<UsedCouponResponse> usedCoupons) {
+public record CouponListResponse(
+        @Schema(description = "사용 가능한 쿠폰 목록")
+        List<AvailableCouponResponse> availableCoupons,
+        @Schema(description = "사용한 쿠폰 목록")
+        List<UsedCouponResponse> usedCoupons
+) {
 
     public static CouponListResponse of(List<AvailableCouponResponse> availableCoupons, List<UsedCouponResponse> usedCoupons) {
         return new CouponListResponse(availableCoupons, usedCoupons);

--- a/offroad-api/src/main/java/site/offload/api/coupon/dto/UsedCouponResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/dto/UsedCouponResponse.java
@@ -1,6 +1,13 @@
 package site.offload.api.coupon.dto;
 
-public record UsedCouponResponse(String name, String couponImageUrl) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UsedCouponResponse(
+        @Schema(description = "쿠폰 이름", example = "쿠폰 이름")
+        String name,
+        @Schema(description = "쿠폰 이미지 URL", example = "https://coupon-image-url.com")
+        String couponImageUrl
+) {
     public static UsedCouponResponse of(String name, String couponImageUrl) {
         return new UsedCouponResponse(name, couponImageUrl);
     }

--- a/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemControllerSwagger.java
@@ -1,32 +1,26 @@
 package site.offload.api.emblem.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 import site.offload.api.emblem.dto.response.EmblemsResponse;
 import site.offload.api.emblem.dto.response.GainedEmblemListResponse;
 import site.offload.api.response.APISuccessResponse;
 
+@Tag(name = "Emblem API", description = "칭호 관련 API")
 public interface EmblemControllerSwagger {
 
     @Operation(summary = "유저의 칭호 변경 API", description = "유저의 칭호를 변경하는 API입니다.")
-    @ApiResponse(responseCode = "200",
-            description = "칭호 변경 완료",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "칭호 변경 완료")
     ResponseEntity<APISuccessResponse<Void>> updateEmblem(@RequestParam(value = "emblemCode") final String emblemCode);
 
     @Operation(summary = "얻은 칭호 조회 API", description = "유저가 획득한 칭호를 조회하는 API 입니다.")
-    @ApiResponse(responseCode = "200",
-            description = "칭호 조회 완료",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "칭호 조회 완료")
     ResponseEntity<APISuccessResponse<GainedEmblemListResponse>> getGainedEmblem();
 
     @Operation(summary = "칭호 조회 API", description = "칭호 목록을 조회하는 API 입니다.")
-    @ApiResponse(responseCode = "200",
-            description = "칭호 조회 완료",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<EmblemsResponse>> getEmblems();
+    @ApiResponse(responseCode = "200", description = "칭호 조회 완료")
+    ResponseEntity<APISuccessResponse<EmblemsResponse>> getEmblems();
 }

--- a/offroad-api/src/main/java/site/offload/api/emblem/dto/request/UpdateCurrentEmblemRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/dto/request/UpdateCurrentEmblemRequest.java
@@ -1,6 +1,13 @@
 package site.offload.api.emblem.dto.request;
 
-public record UpdateCurrentEmblemRequest(String emblemCode, Long memberId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateCurrentEmblemRequest(
+        @Schema(description = "엠블럼 코드", example = "emblemCode")
+        String emblemCode,
+        @Schema(description = "회원 ID", example = "1")
+        Long memberId
+) {
 
     public static UpdateCurrentEmblemRequest of(String emblemCode, Long memberId) {
         return new UpdateCurrentEmblemRequest(emblemCode, memberId);

--- a/offroad-api/src/main/java/site/offload/api/emblem/dto/response/EmblemResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/dto/response/EmblemResponse.java
@@ -1,8 +1,13 @@
 package site.offload.api.emblem.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record EmblemResponse(
+        @Schema(description = "칭호 이름")
         String emblemName,
+        @Schema(description = "칭호 획득 조건 퀘스트 이름")
         String clearConditionQuestName,
+        @Schema(description = "새로 획득한 칭호인지 여부")
         boolean isNewGained
 ) {
     public static EmblemResponse of(String emblemName, String clearConditionQuestName, boolean isNewGained) {

--- a/offroad-api/src/main/java/site/offload/api/emblem/dto/response/EmblemsResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/dto/response/EmblemsResponse.java
@@ -1,9 +1,13 @@
 package site.offload.api.emblem.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record EmblemsResponse(
+        @Schema(description = "획득한 칭호 목록")
         List<EmblemResponse> gainedEmblems,
+        @Schema(description = "획득하지 못한 칭호 목록")
         List<EmblemResponse> notGainedEmblems
 ) {
     public static EmblemsResponse of(List<EmblemResponse> gainedEmblems, List<EmblemResponse> notGainedEmblems){

--- a/offroad-api/src/main/java/site/offload/api/emblem/dto/response/GainedEmblemListResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/dto/response/GainedEmblemListResponse.java
@@ -1,9 +1,14 @@
 package site.offload.api.emblem.dto.response;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
-public record GainedEmblemListResponse(List<GainedEmblemResponse> emblems) {
+public record GainedEmblemListResponse(
+        @Schema(description = "획득한 엠블럼 목록")
+        List<GainedEmblemResponse> emblems
+) {
     public static GainedEmblemListResponse of(List<GainedEmblemResponse> emblems) {
         return new GainedEmblemListResponse(emblems);
     }

--- a/offroad-api/src/main/java/site/offload/api/emblem/dto/response/GainedEmblemResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/dto/response/GainedEmblemResponse.java
@@ -1,7 +1,14 @@
 package site.offload.api.emblem.dto.response;
 
 
-public record GainedEmblemResponse(String emblemCode, String emblemName) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GainedEmblemResponse(
+        @Schema(description = "칭호 코드", example = "EMB001")
+        String emblemCode,
+        @Schema(description = "칭호 이름", example = "테스트 칭호")
+        String emblemName
+) {
 
     public static GainedEmblemResponse of(String emblemCode, String emblemName) {
         return new GainedEmblemResponse(emblemCode, emblemName);

--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,45 +13,46 @@ import site.offload.api.member.dto.request.*;
 import site.offload.api.member.dto.response.*;
 import site.offload.api.response.APISuccessResponse;
 
+@Tag(name = "Member API", description = "사용자 관련 API")
 public interface MemberControllerSwagger {
 
     @Operation(summary = "모험 정보 인증 API", description = "메인 홈에서 모험 인증 정보(닉네임, 캐릭터 이미지 or 모션 이미지, 칭호)반환")
-    @ApiResponse(responseCode = "200", description = "모험 인증 정보 요청 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "모험 인증 정보 요청 성공")
     ResponseEntity<APISuccessResponse<MemberAdventureInformationResponse>> getAdventureInformation(@RequestParam(value = "category") final String category);
 
     @Operation(summary = "프로필 업데이트 API", description = "프로필 업데이트 정보를 받아 멤버 업데이트")
-    @ApiResponse(responseCode = "200", description = "프로필 업데이트 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<Void>> updateMemberProfile(@RequestBody MemberProfileUpdateRequest memberProfileUpdateRequest);
+    @ApiResponse(responseCode = "200", description = "프로필 업데이트 성공")
+    ResponseEntity<APISuccessResponse<Void>> updateMemberProfile(@RequestBody MemberProfileUpdateRequest memberProfileUpdateRequest);
 
 
     @Operation(summary = "닉네임 중복 확인 API", description = "중복된 닉네임이 있는지 확인하는 API")
-    @ApiResponse(responseCode = "200", description = "닉네임 중복 확인 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<NicknameCheckResponse>> checkNickname(@RequestParam(value = "nickname") String nickname);
+    @ApiResponse(responseCode = "200", description = "닉네임 중복 확인 성공")
+    ResponseEntity<APISuccessResponse<NicknameCheckResponse>> checkNickname(@RequestParam(value = "nickname") String nickname);
 
     @Operation(summary = "캐릭터 선택 API", description = "캐릭터를 선택하는 API")
-    @ApiResponse(responseCode = "200", description = "캐릭터 선택 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<ChooseCharacterResponse>> chooseCharacter(@PathVariable(value = "characterId") Integer characterId);
+    @ApiResponse(responseCode = "200", description = "캐릭터 선택 성공")
+    ResponseEntity<APISuccessResponse<ChooseCharacterResponse>> chooseCharacter(@PathVariable(value = "characterId") Integer characterId);
 
     @Operation(summary = "탐험 인증 API", description = "QR코드로 탐험인증 하는 API")
-    @ApiResponse(responseCode = "200", description = "탐험 인증 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "탐험 인증 성공")
     ResponseEntity<APISuccessResponse<VerifyQrcodeResponse>> authAdventure(final @RequestBody AuthAdventureRequest request);
 
 
     @Operation(summary = "위치 정보 탐험 인증 API", description = "QR코드로 탐험인증 하는 API")
-    @ApiResponse(responseCode = "200", description = "탐험 인증 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "탐험 인증 성공")
     ResponseEntity<APISuccessResponse<VerifyPositionDistanceResponse>> authAdventureOnlyPlace(final @RequestBody AuthPositionRequest request);
 
     @Operation(summary = "로그아웃 API", description = "로그아웃 API")
-    @ApiResponse(responseCode = "200", description = "로그아웃 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
     ResponseEntity<APISuccessResponse<Void>> signOut(@RequestBody final SignOutRequest request);
 
     @Operation(summary = "캐릭터 목록 조회 API", description = "캐릭터 목록 조회 API")
-    @ApiResponse(responseCode = "200", description = "캐릭터 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<GainedCharactersResponse>> getGainedCharacters();
+    @ApiResponse(responseCode = "200", description = "캐릭터 목록 조회 성공")
+    ResponseEntity<APISuccessResponse<GainedCharactersResponse>> getGainedCharacters();
 
     @Operation(summary = "마케팅 수신 여부 API", description = "마케팅 수신 여부 API")
-    @ApiResponse(responseCode = "200", description = "마케팅 수신 여부 업데이트 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<Void>> agreeTerms(
+    @ApiResponse(responseCode = "200", description = "마케팅 수신 여부 업데이트 성공")
+    ResponseEntity<APISuccessResponse<Void>> agreeTerms(
             @RequestBody TermsAgreeRequest termsAgreeRequest
     );
 }

--- a/offroad-api/src/main/java/site/offload/api/member/controller/SocialLoginController.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/SocialLoginController.java
@@ -16,7 +16,7 @@ import site.offload.external.oauth.dto.SocialLoginRequest;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/oauth/login")
-public class SocialLoginController {
+public class SocialLoginController implements SocialLoginControllerSwagger {
 
     private final SocialLoginUseCase socialLoginUseCase;
 

--- a/offroad-api/src/main/java/site/offload/api/member/controller/SocialLoginControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/SocialLoginControllerSwagger.java
@@ -4,19 +4,19 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import site.offload.api.member.dto.response.SocialLoginResponse;
 import site.offload.api.response.APISuccessResponse;
 import site.offload.external.oauth.dto.SocialLoginRequest;
 
+@Tag(name = "Social Login API", description = "소셜 로그인 API")
 public interface SocialLoginControllerSwagger {
 
     @Operation(summary = "소셜 로그인 API", description = "구글 및 애플 소셜 로그인 구현")
-    @ApiResponse(responseCode = "200",
-            description = "소셜 로그인 성공",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<SocialLoginResponse>> login(
+    @ApiResponse(responseCode = "200", description = "소셜 로그인 성공")
+    ResponseEntity<APISuccessResponse<SocialLoginResponse>> login(
             @RequestBody SocialLoginRequest socialLoginRequest
     );
 }

--- a/offroad-api/src/main/java/site/offload/api/member/controller/TestMemberController.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/TestMemberController.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 @RestController
 @RequestMapping("/dev/api")
 @RequiredArgsConstructor
-public class TestMemberController {
+public class TestMemberController implements TestMemberControllerSwagger {
 
     private final TestMemberDeleteUseCase testMemberDeleteUseCase;
     private final Environment environment;

--- a/offroad-api/src/main/java/site/offload/api/member/controller/TestMemberControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/TestMemberControllerSwagger.java
@@ -1,0 +1,18 @@
+package site.offload.api.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import site.offload.api.member.dto.request.TestMemberDeleteRequest;
+import site.offload.api.response.APISuccessResponse;
+
+
+@Tag(name = "TestMember API", description = "테스트 멤버 API(dev 환경에서만 동작합니다.)")
+public interface TestMemberControllerSwagger {
+
+    @Operation(summary = "테스트 멤버 삭제 API", description = "테스트 멤버를 삭제하는 API")
+    @ApiResponse(responseCode = "200", description = "테스트 멤버 삭제 성공")
+    ResponseEntity<APISuccessResponse<Void>> deleteTestMember(@RequestBody TestMemberDeleteRequest request);
+}

--- a/offroad-api/src/main/java/site/offload/api/member/controller/TokenControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/TokenControllerSwagger.java
@@ -4,16 +4,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestHeader;
 import site.offload.api.member.dto.response.TokenReissueResponse;
 import site.offload.api.response.APISuccessResponse;
 
+@Tag(name = "Token API", description = "토큰 API")
 public interface TokenControllerSwagger {
 
     @Operation(summary = "토큰 재발급 API", description = "Refresh Token으로 Access Token, Refresh Token을 재발급하는 API입니다.")
-    @ApiResponse(responseCode = "201",
-            description = "토큰 재발급 완료",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "201", description = "토큰 재발급 완료")
     ResponseEntity<APISuccessResponse<TokenReissueResponse>> refreshToken(@RequestHeader("Authorization") String tokenHeaderValue);
 }

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/AuthAdventureRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/AuthAdventureRequest.java
@@ -1,4 +1,15 @@
 package site.offload.api.member.dto.request;
 
-public record AuthAdventureRequest(Long placeId, double longitude, double latitude, String qrCode) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AuthAdventureRequest(
+        @Schema(description = "장소 ID", example = "1")
+        Long placeId,
+        @Schema(description = "장소 이름", example = "테스트 장소")
+        double longitude,
+        @Schema(description = "장소 위도", example = "37.123456")
+        double latitude,
+        @Schema(description = "QR 코드", example = "https://test.com")
+        String qrCode
+) {
 }

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/AuthPositionRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/AuthPositionRequest.java
@@ -1,4 +1,12 @@
 package site.offload.api.member.dto.request;
 
-public record AuthPositionRequest(Long placeId, double latitude, double longitude) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AuthPositionRequest(
+        @Schema(description = "장소 ID", example = "1")
+        Long placeId,
+        @Schema(description = "위도", example = "37.123456")
+        double latitude,
+        @Schema(description = "경도", example = "127.123456")
+        double longitude) {
 }

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/MemberAdventureInformationRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/MemberAdventureInformationRequest.java
@@ -1,6 +1,12 @@
 package site.offload.api.member.dto.request;
 
-public record MemberAdventureInformationRequest(Long memberId, String category) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberAdventureInformationRequest(
+        @Schema(description = "회원 ID", example = "1")
+        Long memberId,
+        @Schema(description = "카테고리", example = "category")
+        String category) {
 
     public static MemberAdventureInformationRequest of(final Long memberId, final String category) {
         return new MemberAdventureInformationRequest(memberId, category);

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/MemberDeleteRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/MemberDeleteRequest.java
@@ -1,4 +1,9 @@
 package site.offload.api.member.dto.request;
 
-public record MemberDeleteRequest(String deleteCode) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberDeleteRequest(
+        @Schema(description = "회원 삭제 코드", example = "deleteCode")
+        String deleteCode
+) {
 }

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/MemberProfileUpdateRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/MemberProfileUpdateRequest.java
@@ -1,13 +1,19 @@
 package site.offload.api.member.dto.request;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.offload.enums.member.MemberGender;
 
 public record MemberProfileUpdateRequest(
+        @Schema(description = "닉네임", example = "닉네임")
         String nickname,
+        @Schema(description = "년도", example = "2021")
         Integer year,
+        @Schema(description = "월", example = "1")
         Integer month,
+        @Schema(description = "일", example = "1")
         Integer day,
+        @Schema(description = "성별", example = "MALE")
         MemberGender gender
 ) {
     public static MemberProfileUpdateRequest of(String nickname, Integer year, Integer month, Integer day, MemberGender gender) {

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/SignOutRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/SignOutRequest.java
@@ -1,6 +1,9 @@
 package site.offload.api.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record SignOutRequest(
+    @Schema(description = "Refresh Token", example = "refreshToken")
     String refreshToken
 ) {
 }

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/TermsAgreeRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/TermsAgreeRequest.java
@@ -1,6 +1,9 @@
 package site.offload.api.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record TermsAgreeRequest(
+        @Schema(description = "회원 ID", example = "1")
         boolean marketing
 ) {
 }

--- a/offroad-api/src/main/java/site/offload/api/member/dto/request/TestMemberDeleteRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/request/TestMemberDeleteRequest.java
@@ -1,11 +1,13 @@
 package site.offload.api.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.offload.api.exception.BadRequestException;
 import site.offload.enums.response.ErrorMessage;
 
 import java.util.List;
 
 public record TestMemberDeleteRequest(
+        @Schema(description = "이름", example = "민성")
         String name
 ) {
     public TestMemberDeleteRequest {

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/ChooseCharacterResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/ChooseCharacterResponse.java
@@ -1,6 +1,11 @@
 package site.offload.api.member.dto.response;
 
-public record ChooseCharacterResponse(String characterImageUrl) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ChooseCharacterResponse(
+        @Schema(description = "캐릭터 이미지 URL", example = "https://test.com/test.jpg")
+        String characterImageUrl
+) {
     public static ChooseCharacterResponse of(String characterImageUrl) {
         return new ChooseCharacterResponse(characterImageUrl);
     }

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharacterResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharacterResponse.java
@@ -1,11 +1,20 @@
 package site.offload.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "획득한 캐릭터 정보")
 public record GainedCharacterResponse(
+        @Schema(description = "캐릭터 ID", example = "1")
         Integer characterId,
+        @Schema(description = "캐릭터 이름", example = "테스트 캐릭터")
         String characterName,
+        @Schema(description = "캐릭터 썸네일 이미지 URL", example = "https://test.com/test.jpg")
         String characterThumbnailImageUrl,
+        @Schema(description = "캐릭터 메인 색상 코드", example = "FFFFFF")
         String characterMainColorCode,
+        @Schema(description = "캐릭터 서브 색상 코드", example = "000000")
         String characterSubColorCode,
+        @Schema(description = "신규 획득 여부", example = "true")
         boolean isNewGained
 ) {
     public static GainedCharacterResponse of(Integer characterId, String characterName, String characterThumbnailImageUrl, String characterMainColorCode, String characterSubColorCode, boolean isNewGained) {

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharactersResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/GainedCharactersResponse.java
@@ -1,10 +1,16 @@
 package site.offload.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "획득한 캐릭터 응답 목록")
 public record GainedCharactersResponse(
+        @Schema(description = "획득한 캐릭터 목록")
         List<GainedCharacterResponse> gainedCharacters,
+        @Schema(description = "미획득한 캐릭터 목록")
         List<GainedCharacterResponse> notGainedCharacters,
+        @Schema(description = "대표 캐릭터 ID", example = "1")
         Integer representativeCharacterId
 ) {
     public static GainedCharactersResponse of(List<GainedCharacterResponse> gainedCharacters, List<GainedCharacterResponse> notGainedCharacters, Integer representativeCharacterId) {

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/MemberAdventureInformationResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/MemberAdventureInformationResponse.java
@@ -1,12 +1,22 @@
 package site.offload.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record MemberAdventureInformationResponse(String nickname, String emblemName, String baseImageUrl,
-                                                 String motionImageUrl,
-                                                 String characterName,
-                                                 String motionCaptureImageUrl) {
+public record MemberAdventureInformationResponse(
+        @Schema(description = "닉네임", example = "테스트 닉네임")
+        String nickname,
+        @Schema(description = "칭호 이름", example = "테스트 칭호")
+        String emblemName,
+        @Schema(description = "기본 이미지 URL", example = "https://test.com/test.jpg")
+        String baseImageUrl,
+        @Schema(description = "모션 이미지 URL", example = "https://test.com/test.jpg")
+        String motionImageUrl,
+        @Schema(description = "캐릭터 이름", example = "테스트 캐릭터")
+        String characterName,
+        @Schema(description = "모션 캡쳐 이미지 URL", example = "https://test.com/test.jpg")
+        String motionCaptureImageUrl) {
 
     public static MemberAdventureInformationResponse of(final String nickname, final String emblemName,
                                                         final String baseImageUrl, final String motionImageUrl, final String characterName, final String motionCaptureImageUrl) {

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/NicknameCheckResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/NicknameCheckResponse.java
@@ -1,6 +1,9 @@
 package site.offload.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record NicknameCheckResponse(
+        @Schema(description = "닉네임 중복 여부", example = "true")
         boolean isDuplicate
 ) {
     public static NicknameCheckResponse of(boolean isDuplicate) {

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/SocialLoginResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/SocialLoginResponse.java
@@ -1,10 +1,13 @@
 package site.offload.api.member.dto.response;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.offload.api.auth.jwt.TokenResponse;
 
 public record SocialLoginResponse(
+        @Schema(description = "토큰 정보")
         TokenResponse tokens,
+        @Schema(description = "이미 가입된 회원인지 여부", example = "true")
         boolean isAlreadyExist
 ) {
     public static SocialLoginResponse of(TokenResponse tokens, boolean isAlreadyExist) {

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/TokenReissueResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/TokenReissueResponse.java
@@ -1,6 +1,12 @@
 package site.offload.api.member.dto.response;
 
-public record TokenReissueResponse(String accessToken, String refreshToken) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenReissueResponse(
+        @Schema(description = "액세스 토큰", example = "accessToken")
+        String accessToken,
+        @Schema(description = "리프레시 토큰", example = "refreshToken")
+        String refreshToken) {
 
     public static TokenReissueResponse of(final String accessToken, final String refreshToken) {
         return new TokenReissueResponse(accessToken, refreshToken);

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/UserInfoResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/UserInfoResponse.java
@@ -1,10 +1,17 @@
 package site.offload.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UserInfoResponse(
+        @Schema(description = "닉네임", example = "nickname")
         String nickname,
+        @Schema(description = "현재 엠블럼", example = "emblem")
         String currentEmblem,
+        @Schema(description = "누적 일수", example = "1")
         long elapsedDay,
+        @Schema(description = "완료 퀘스트 수", example = "1")
         long completeQuestCount,
+        @Schema(description = "방문한 장소 수", example = "1")
         long visitedPlaceCount
 
 ) {

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/VerifyPositionDistanceResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/VerifyPositionDistanceResponse.java
@@ -1,11 +1,18 @@
 package site.offload.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.offload.api.quest.dto.response.CompleteQuestResponse;
 
 import java.util.List;
 
-public record VerifyPositionDistanceResponse(boolean isValidPosition, String successCharacterImageUrl,
-                                             List<CompleteQuestResponse> completeQuestList) {
+public record VerifyPositionDistanceResponse(
+        @Schema(description = "유효한 위치 여부", example = "true")
+        boolean isValidPosition,
+        @Schema(description = "캐릭터 이미지 URL", example = "https://test.com/test.jpg")
+        String successCharacterImageUrl,
+        @Schema(description = "완료한 퀘스트 목록")
+
+        List<CompleteQuestResponse> completeQuestList) {
 
     public static VerifyPositionDistanceResponse of(boolean isValidPosition, String characterImageUrl, List<CompleteQuestResponse> completeQuestList) {
         return new VerifyPositionDistanceResponse(isValidPosition, characterImageUrl, completeQuestList);

--- a/offroad-api/src/main/java/site/offload/api/member/dto/response/VerifyQrcodeResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/member/dto/response/VerifyQrcodeResponse.java
@@ -1,11 +1,19 @@
 package site.offload.api.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.offload.api.quest.dto.response.CompleteQuestResponse;
 
 import java.util.List;
 
-public record VerifyQrcodeResponse(boolean isQRMatched, String characterImageUrl,
-                                   List<CompleteQuestResponse> completeQuestList) {
+public record VerifyQrcodeResponse(
+        @Schema(description = "인증코드 일치 여부", example = "true")
+        boolean isQRMatched,
+        @Schema(description = "캐릭터 이미지 URL", example = "https://test.com/test.jpg")
+        String characterImageUrl,
+
+        @Schema(description = "완료한 퀘스트 목록")
+        List<CompleteQuestResponse> completeQuestList
+) {
 
     public static VerifyQrcodeResponse of(boolean isQRMatched, String characterImageUrl, List<CompleteQuestResponse> completeQuestList) {
         return new VerifyQrcodeResponse(isQRMatched, characterImageUrl, completeQuestList);

--- a/offroad-api/src/main/java/site/offload/api/place/controller/PlaceController.java
+++ b/offroad-api/src/main/java/site/offload/api/place/controller/PlaceController.java
@@ -17,7 +17,6 @@ import site.offload.enums.response.SuccessMessage;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-@Tag(name = "Place API", description = "장소 관련 API")
 public class PlaceController implements PlaceControllerSwagger {
 
     private final PlaceUseCase placeUsecase;

--- a/offroad-api/src/main/java/site/offload/api/place/controller/PlaceControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/place/controller/PlaceControllerSwagger.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,11 +16,11 @@ import site.offload.api.place.dto.response.UnvisitedPlacesResponse;
 import site.offload.api.response.APISuccessResponse;
 import site.offload.enums.response.SuccessMessage;
 
+@Tag(name = "Place API", description = "장소 관련 API")
+
 public interface PlaceControllerSwagger {
     @Operation(summary = "오프로드 등록 장소 조회 API", description = "오프로드 등록 장소 조회 API입니다.")
-    @ApiResponse(responseCode = "200",
-            description = "오프로드 등록 장소 조회 완료",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
+    @ApiResponse(responseCode = "200", description = "오프로드 등록 장소 조회 완료")
             ResponseEntity<APISuccessResponse<RegisteredPlacesResponse>> getPlaces(
             @RequestParam double currentLatitude,
             @RequestParam double currentLongitude,

--- a/offroad-api/src/main/java/site/offload/api/place/dto/request/RegisteredPlacesRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/request/RegisteredPlacesRequest.java
@@ -1,7 +1,11 @@
 package site.offload.api.place.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record RegisteredPlacesRequest(
+        @Schema(description = "현재 위도", example = "37.123456")
         double currentLatitude,
+        @Schema(description = "현재 경도", example = "127.123456")
         double currentLongitude
 ) {
     public static RegisteredPlacesRequest of(

--- a/offroad-api/src/main/java/site/offload/api/place/dto/request/UnvisitedPlacesRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/request/UnvisitedPlacesRequest.java
@@ -1,8 +1,13 @@
 package site.offload.api.place.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UnvisitedPlacesRequest(
+        @Schema(description = "현재 위도", example = "37.123456")
         double currentLatitude,
-        double currentLongitude) {
+        @Schema(description = "현재 경도", example = "127.123456")
+        double currentLongitude
+) {
     public static UnvisitedPlacesRequest of(
             double currentLatitude,
             double currentLongitude

--- a/offroad-api/src/main/java/site/offload/api/place/dto/response/RegisteredPlaceResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/response/RegisteredPlaceResponse.java
@@ -1,19 +1,30 @@
 package site.offload.api.place.dto.response;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.offload.enums.place.PlaceArea;
 import site.offload.enums.place.PlaceCategory;
 
 public record RegisteredPlaceResponse(
+        @Schema(description = "장소 ID", example = "1")
         Long id,
+        @Schema(description = "장소 이름", example = "테스트 장소")
         String name,
+        @Schema(description = "장소 주소", example = "서울시 강남구 테스트로 123")
         String address,
+        @Schema(description = "장소 간단 소개", example = "테스트 장소입니다.")
         String shortIntroduction,
+        @Schema(description = "장소 카테고리", example = "RESTAURANT")
         PlaceCategory placeCategory,
+        @Schema(description = "장소 지역", example = "SEOUL")
         PlaceArea placeArea,
+        @Schema(description = "위도", example = "37.123456")
         double latitude,
+        @Schema(description = "경도", example = "127.123456")
         double longitude,
+        @Schema(description = "방문 횟수", example = "100")
         Long visitCount,
+        @Schema(description = "카테고리 이미지 URL", example = "https://test.com/test.jpg")
         String categoryImageUrl
 ) {
     public static RegisteredPlaceResponse of(

--- a/offroad-api/src/main/java/site/offload/api/place/dto/response/RegisteredPlacesResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/response/RegisteredPlacesResponse.java
@@ -1,8 +1,11 @@
 package site.offload.api.place.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record RegisteredPlacesResponse(
+        @Schema(description = "등록된 장소 목록")
         List<RegisteredPlaceResponse> places
 ) {
     public static RegisteredPlacesResponse of(List<RegisteredPlaceResponse> places) {

--- a/offroad-api/src/main/java/site/offload/api/place/dto/response/UnvisitedPlaceResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/response/UnvisitedPlaceResponse.java
@@ -1,16 +1,26 @@
 package site.offload.api.place.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.offload.enums.place.PlaceCategory;
 
 public record UnvisitedPlaceResponse(
+        @Schema(description = "장소 ID", example = "1")
         Long id,
+        @Schema(description = "장소 이름", example = "테스트 장소")
         String name,
+        @Schema(description = "장소 주소", example = "서울시 강남구")
         String address,
+        @Schema(description = "장소 간단 소개", example = "테스트 장소입니다.")
         String shortIntroduction,
+        @Schema(description = "장소 카테고리", example = "RESTAURANT")
         PlaceCategory placeCategory,
+        @Schema(description = "장소 위도", example = "37.123456")
         double latitude,
+        @Schema(description = "장소 경도", example = "127.123456")
         double longitude,
+        @Schema(description = "장소 방문 횟수", example = "1")
         Long visitCount,
+        @Schema(description = "장소 카테고리 이미지 URL", example = "https://test.com")
         String categoryImageUrl
 ) {
     public static UnvisitedPlaceResponse of(

--- a/offroad-api/src/main/java/site/offload/api/place/dto/response/UnvisitedPlacesResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/place/dto/response/UnvisitedPlacesResponse.java
@@ -1,8 +1,11 @@
 package site.offload.api.place.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record UnvisitedPlacesResponse(
+        @Schema(description = "방문하지 않은 장소 목록")
         List<UnvisitedPlaceResponse> places
 ) {
     public static UnvisitedPlacesResponse of(List<UnvisitedPlaceResponse> places) {

--- a/offroad-api/src/main/java/site/offload/api/quest/controller/QuestControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/controller/QuestControllerSwagger.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 import site.offload.api.quest.dto.request.QuestDetailListRequest;
@@ -11,17 +12,14 @@ import site.offload.api.quest.dto.response.QuestDetailListResponse;
 import site.offload.api.quest.dto.response.QuestResponse;
 import site.offload.api.response.APISuccessResponse;
 
+@Tag(name = "Quest API", description = "퀘스트 관련 API")
 public interface QuestControllerSwagger {
 
     @Operation(summary = "퀘스트 정보 조회 API", description = "퀘스트 정보를 조회하는 API입니다.")
-    @ApiResponse(responseCode = "200",
-            description = "퀘스트 정보 조회 완료",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<QuestResponse>> getQuestInformation();
+    @ApiResponse(responseCode = "200", description = "퀘스트 정보 조회 완료")
+    ResponseEntity<APISuccessResponse<QuestResponse>> getQuestInformation();
 
     @Operation(summary = "퀘스트 목록 조회 API", description = "퀘스트 목록 탭의 정보를 조회하는 API입니다.")
-    @ApiResponse(responseCode = "200",
-            description = "퀘스트 목록 정보 조회 완료",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = APISuccessResponse.class)))
-    public ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam boolean isActive);
+    @ApiResponse(responseCode = "200", description = "퀘스트 목록 정보 조회 완료")
+    ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam boolean isActive);
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/request/QuestDetailListRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/request/QuestDetailListRequest.java
@@ -1,4 +1,8 @@
 package site.offload.api.quest.dto.request;
 
-public record QuestDetailListRequest(boolean isActive) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record QuestDetailListRequest(
+        @Schema(description = "퀘스트 진행 여부", example = "true")
+        boolean isActive) {
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/response/CompleteQuestResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/response/CompleteQuestResponse.java
@@ -1,6 +1,11 @@
 package site.offload.api.quest.dto.response;
 
-public record CompleteQuestResponse(String name) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CompleteQuestResponse(
+        @Schema(description = "퀘스트 이름", example = "테스트 퀘스트")
+        String name
+) {
 
     public static CompleteQuestResponse of(String name) {
         return new CompleteQuestResponse(name);

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailListResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailListResponse.java
@@ -1,8 +1,13 @@
 package site.offload.api.quest.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
-public record QuestDetailListResponse(List<QuestDetailResponse> questList) {
+public record QuestDetailListResponse(
+        @Schema(description = "퀘스트 목록")
+        List<QuestDetailResponse> questList
+) {
     public static QuestDetailListResponse of(List<QuestDetailResponse> questList) {
         return new QuestDetailListResponse(questList);
     }

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailResponse.java
@@ -1,11 +1,22 @@
 package site.offload.api.quest.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record QuestDetailResponse(String questName, String description,
-                                  int currentCount, int totalCount, String requirement,
-                                  String reward) {
+public record QuestDetailResponse(
+        @Schema(description = "퀘스트 이름", example = "테스트 퀘스트")
+        String questName,
+        @Schema(description = "퀘스트 설명", example = "테스트 퀘스트 설명")
+        String description,
+        @Schema(description = "퀘스트 진행도", example = "1")
+        int currentCount,
+        @Schema(description = "퀘스트 완료 조건", example = "3")
+        int totalCount,
+        @Schema(description = "퀘스트 완료 조건", example = "3")
+        String requirement,
+        @Schema(description = "퀘스트 보상", example = "~쿠폰")
+        String reward) {
 
     public static QuestDetailResponse of(String questName, String description,
                                          int currentCount, int totalCount, String requirement,

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestInformationResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestInformationResponse.java
@@ -1,8 +1,13 @@
 package site.offload.api.quest.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record QuestInformationResponse(
+        @Schema(description = "퀘스트 이름", example = "테스트 퀘스트")
         String questName,
+        @Schema(description = "퀘스트 진행도", example = "1")
         int progress,
+        @Schema(description = "퀘스트 완료 조건", example = "3")
         int completeCondition
 ) {
     public static QuestInformationResponse of(String questName, int progress, int completeCondition) {

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestResponse.java
@@ -1,7 +1,10 @@
 package site.offload.api.quest.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 public record QuestResponse(
+        @Schema(description = "최근 퀘스트 정보")
         QuestInformationResponse recent,
+        @Schema(description = "거의 완료된 퀘스트 정보")
         QuestInformationResponse almost
 ) {
     public static QuestResponse of(QuestInformationResponse recent, QuestInformationResponse almost) {

--- a/offroad-api/src/main/java/site/offload/api/response/APISuccessResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/response/APISuccessResponse.java
@@ -1,9 +1,12 @@
 package site.offload.api.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.http.ResponseEntity;
 
 public record APISuccessResponse<T>(
+        @Schema(description = "응답 메시지", example = "RESPONSE_SUCCESS")
         String message,
+        @Schema(description = "응답 데이터")
         T data
 ) {
     public static <T> ResponseEntity<APISuccessResponse<T>> of(int statusCode, String message, T data) {


### PR DESCRIPTION
## 변경사항
 - Swagger 상에 요청/응답 정보를 확인할 수 있도록 작업 진행했습니다.
 <img width="1244" alt="image" src="https://github.com/user-attachments/assets/e28a6f0f-4c2e-4c23-9a45-f0095864c065">

- 기타 스타일 작업을 진행했습니다.

## 고려사항
- 해당 PR merge하고 조금 더 Style 정리를 하도록 하겠습니다~

