### PR TITLE
refact : swagger 명세서 업데이트

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/character/controller/CharacterControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/character/controller/CharacterControllerSwagger.java
@@ -1,6 +1,8 @@
 package site.offload.api.character.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,11 +16,16 @@ import site.offload.api.response.APISuccessResponse;
 @Tag(name = "Character API", description = "캐릭터 관련 API")
 public interface CharacterControllerSwagger {
 
-    @Operation(summary = "캐릭터 조회 API", description = "캐릭터 목록 조회 API")
+    @Operation(summary = "시작 캐릭터 조회 API", description = "시작 시 선택할 수 있는 캐릭터를 조회하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "캐릭터 목록 조회 성공")
     ResponseEntity<APISuccessResponse<StartCharactersResponse>> getStartCharacters();
 
-    @Operation(summary = "캐릭터 상세 목록 조회 API", description = "캐릭터 상세 목록 조회 API")
+    @Operation(summary = "캐릭터 상세 정보 조회 API", description = "캐릭터의 정보를 상세 조회할 수 있는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "캐릭터 상세 목록 조회 성공")
-    ResponseEntity<APISuccessResponse<CharacterDetailResponse>> getCharacterDetail(Integer characterId);
+    ResponseEntity<APISuccessResponse<CharacterDetailResponse>> getCharacterDetail(
+            @Parameter(name = "characterId", description = "캐릭터 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Integer"))
+            Integer characterId
+    );
 }

--- a/offroad-api/src/main/java/site/offload/api/charactermotion/controller/CharacterMotionControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/charactermotion/controller/CharacterMotionControllerSwagger.java
@@ -1,6 +1,9 @@
 package site.offload.api.charactermotion.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -10,7 +13,10 @@ import site.offload.api.response.APISuccessResponse;
 @Tag(name = "CharacterMotion API", description = "캐릭터 모션 API")
 public interface CharacterMotionControllerSwagger {
 
-    @Operation(summary = "캐릭터 모션 목록 조회 API", description = "캐릭터 모션 목록 조회 API")
+    @Operation(summary = "캐릭터 모션 목록 조회 API", description = "캐릭터 모션 목록을 조회할 수 있는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "캐릭터 모션 목록 조회 성공")
-    ResponseEntity<APISuccessResponse<CharacterMotionsResponse>> getMotions(Integer characterId);
+    ResponseEntity<APISuccessResponse<CharacterMotionsResponse>> getMotions(
+            @Parameter(name = "characterId", description = "캐릭터 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Integer"))
+            Integer characterId);
 }

--- a/offroad-api/src/main/java/site/offload/api/coupon/controller/CouponControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/controller/CouponControllerSwagger.java
@@ -1,6 +1,8 @@
 package site.offload.api.coupon.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -19,11 +21,13 @@ import site.offload.enums.response.SuccessMessage;
 @Tag(name = "Coupon API", description = "쿠폰 관련 API")
 public interface CouponControllerSwagger {
 
-    @Operation(summary = "획득 쿠폰 목록 조회 API", description = "사용한 쿠폰, 사용된 쿠폰 반환하는 API")
-    @ApiResponse(responseCode = "200", description = "획득 쿠폰 조회 요청 성공")
+    @Operation(summary = "획득 쿠폰 목록 조회 API", description = "사용한 쿠폰과 사용된 쿠폰을 반환하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
+    @ApiResponse(responseCode = "200", description = "획득 쿠폰 목록 조회 성공")
     ResponseEntity<APISuccessResponse<CouponListResponse>> getCouponList();
 
-    @Operation(summary = "쿠폰 적용 API", description = "쿠폰 적용 API")
-    @ApiResponse(responseCode = "200", description = "쿠폰 적용 성공")
+    @Operation(summary = "쿠폰 사용 API", description = "쿠폰을 사용하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
+    @ApiResponse(responseCode = "200", description = "쿠폰 사용 성공")
     public ResponseEntity<APISuccessResponse<CouponApplyResponse>> useCoupon(CouponApplyRequest request);
 }

--- a/offroad-api/src/main/java/site/offload/api/coupon/dto/AvailableCouponResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/dto/AvailableCouponResponse.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record AvailableCouponResponse(
         @Schema(description = "쿠폰 ID", example = "1")
-
         long id,
         @Schema(description = "쿠폰 이름", example = "쿠폰 이름")
         String name,

--- a/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemController.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemController.java
@@ -23,7 +23,7 @@ public class EmblemController implements EmblemControllerSwagger {
     public ResponseEntity<APISuccessResponse<Void>> updateEmblem(@RequestParam(value = "emblemCode") final String emblemCode) {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         emblemUseCase.updateCurrentEmblem(UpdateCurrentEmblemRequest.of(emblemCode, memberId));
-        return APISuccessResponse.of(HttpStatus.OK.value(),
+        return APISuccessResponse.of(HttpStatus.NO_CONTENT.value(),
                 SuccessMessage.MEMBER_CURRENT_EMBLEM_UPDATE_SUCCESS.getMessage(), null);
     }
 

--- a/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/controller/EmblemControllerSwagger.java
@@ -1,6 +1,9 @@
 package site.offload.api.emblem.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -12,15 +15,19 @@ import site.offload.api.response.APISuccessResponse;
 @Tag(name = "Emblem API", description = "칭호 관련 API")
 public interface EmblemControllerSwagger {
 
-    @Operation(summary = "유저의 칭호 변경 API", description = "유저의 칭호를 변경하는 API입니다.")
-    @ApiResponse(responseCode = "200", description = "칭호 변경 완료")
-    ResponseEntity<APISuccessResponse<Void>> updateEmblem(@RequestParam(value = "emblemCode") final String emblemCode);
+    @Operation(summary = "칭호 변경 API", description = "유저의 칭호를 변경하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
+    @ApiResponse(responseCode = "204", description = "칭호 변경 완료")
+    ResponseEntity<APISuccessResponse<Void>> updateEmblem(
+            @Parameter(name = "emblemCode", description = "칭호 코드", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "String")) final String emblemCode);
 
-    @Operation(summary = "얻은 칭호 조회 API", description = "유저가 획득한 칭호를 조회하는 API 입니다.")
+    @Operation(summary = "획득 칭호 목록 조회 API", description = "유저가 획득한 칭호를 조회하는 API 입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "칭호 조회 완료")
     ResponseEntity<APISuccessResponse<GainedEmblemListResponse>> getGainedEmblem();
 
-    @Operation(summary = "칭호 조회 API", description = "칭호 목록을 조회하는 API 입니다.")
+    @Operation(summary = "전체 칭호 목록 조회 API", description = "전체 칭호 목록을 조회하는 API 입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "칭호 조회 완료")
     ResponseEntity<APISuccessResponse<EmblemsResponse>> getEmblems();
 }

--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberController.java
@@ -35,7 +35,7 @@ public class MemberController implements MemberControllerSwagger {
     public ResponseEntity<APISuccessResponse<Void>> updateMemberProfile(@RequestBody MemberProfileUpdateRequest memberProfileUpdateRequest) {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         memberUseCase.updateMemberProfile(memberId, memberProfileUpdateRequest);
-        return APISuccessResponse.of(HttpStatus.OK.value(),
+        return APISuccessResponse.of(HttpStatus.NO_CONTENT.value(),
                 SuccessMessage.MEMBER_PROFILE_UPDATE_SUCCESS.getMessage(), null);
     }
 
@@ -67,7 +67,7 @@ public class MemberController implements MemberControllerSwagger {
     @PostMapping("/sign-out")
     public ResponseEntity<APISuccessResponse<Void>> signOut(@RequestBody final SignOutRequest request) {
         signOutUseCase.execute(request);
-        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.SIGN_OUT_SUCCESS.getMessage(), null);
+        return APISuccessResponse.of(HttpStatus.NO_CONTENT.value(), SuccessMessage.SIGN_OUT_SUCCESS.getMessage(), null);
     }
 
     @GetMapping("/characters")
@@ -95,6 +95,6 @@ public class MemberController implements MemberControllerSwagger {
     ) {
         final Long memberId = PrincipalHandler.getMemberIdFromPrincipal();
         memberUseCase.updateAgreeTerms(memberId, termsAgreeRequest.marketing());
-        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.CHECK_AGREE_TERMS_SUCCESS.getMessage(), null);
+        return APISuccessResponse.of(HttpStatus.NO_CONTENT.value(), SuccessMessage.CHECK_AGREE_TERMS_SUCCESS.getMessage(), null);
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/MemberControllerSwagger.java
@@ -1,6 +1,8 @@
 package site.offload.api.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -16,42 +18,66 @@ import site.offload.api.response.APISuccessResponse;
 @Tag(name = "Member API", description = "사용자 관련 API")
 public interface MemberControllerSwagger {
 
-    @Operation(summary = "모험 정보 인증 API", description = "메인 홈에서 모험 인증 정보(닉네임, 캐릭터 이미지 or 모션 이미지, 칭호)반환")
+    @Operation(summary = "모험 정보 API", description = "메인 홈에서 사용자의 모험 정보(닉네임, 캐릭터 이미지 or 모션 이미지, 칭호)를 조회하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "모험 인증 정보 요청 성공")
-    ResponseEntity<APISuccessResponse<MemberAdventureInformationResponse>> getAdventureInformation(@RequestParam(value = "category") final String category);
+    ResponseEntity<APISuccessResponse<MemberAdventureInformationResponse>> getAdventureInformation(
+            @Parameter(name = "category", description = "장소 카테고리", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "String")) final String category);
 
-    @Operation(summary = "프로필 업데이트 API", description = "프로필 업데이트 정보를 받아 멤버 업데이트")
-    @ApiResponse(responseCode = "200", description = "프로필 업데이트 성공")
+    @Operation(summary = "사용자 프로필 업데이트 API", description = "사용자의 프로필 정보를 받아 업데이트하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
+    @ApiResponse(responseCode = "204", description = "프로필 업데이트 성공")
     ResponseEntity<APISuccessResponse<Void>> updateMemberProfile(@RequestBody MemberProfileUpdateRequest memberProfileUpdateRequest);
 
 
-    @Operation(summary = "닉네임 중복 확인 API", description = "중복된 닉네임이 있는지 확인하는 API")
+    @Operation(summary = "닉네임 중복 확인 API", description = "중복된 닉네임이 있는지 확인하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "닉네임 중복 확인 성공")
-    ResponseEntity<APISuccessResponse<NicknameCheckResponse>> checkNickname(@RequestParam(value = "nickname") String nickname);
+    ResponseEntity<APISuccessResponse<NicknameCheckResponse>> checkNickname(
+            @Parameter(name = "nickname", description = "닉네임", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "String"))
+            String nickname);
 
-    @Operation(summary = "캐릭터 선택 API", description = "캐릭터를 선택하는 API")
-    @ApiResponse(responseCode = "200", description = "캐릭터 선택 성공")
-    ResponseEntity<APISuccessResponse<ChooseCharacterResponse>> chooseCharacter(@PathVariable(value = "characterId") Integer characterId);
+    @Operation(summary = "캐릭터 선택 API", description = "캐릭터를 선택하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
+    @ApiResponse(responseCode = "201", description = "캐릭터 선택 성공")
+    ResponseEntity<APISuccessResponse<ChooseCharacterResponse>> chooseCharacter(
+            @Parameter(name = "characterId", description = "캐릭터 아이디", in = ParameterIn.PATH, required = true, schema = @Schema(type = "Integer"))
+            Integer characterId);
 
-    @Operation(summary = "탐험 인증 API", description = "QR코드로 탐험인증 하는 API")
+    @Operation(summary = "탐험 QR 인증 API", description = "QR코드로 탐험을 인증하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "탐험 인증 성공")
     ResponseEntity<APISuccessResponse<VerifyQrcodeResponse>> authAdventure(final @RequestBody AuthAdventureRequest request);
 
 
-    @Operation(summary = "위치 정보 탐험 인증 API", description = "QR코드로 탐험인증 하는 API")
+    @Operation(summary = "탐험 위치 인증 API", description = "위치 대조로 탐험을 인증하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "탐험 인증 성공")
     ResponseEntity<APISuccessResponse<VerifyPositionDistanceResponse>> authAdventureOnlyPlace(final @RequestBody AuthPositionRequest request);
 
-    @Operation(summary = "로그아웃 API", description = "로그아웃 API")
-    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    @Operation(summary = "로그아웃 API", description = "로그아웃 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
+    @ApiResponse(responseCode = "204", description = "로그아웃 성공")
     ResponseEntity<APISuccessResponse<Void>> signOut(@RequestBody final SignOutRequest request);
 
-    @Operation(summary = "캐릭터 목록 조회 API", description = "캐릭터 목록 조회 API")
+    @Operation(summary = "전체 캐릭터 목록 조회 API", description = "전체 캐릭터 목록을 조회하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "캐릭터 목록 조회 성공")
     ResponseEntity<APISuccessResponse<GainedCharactersResponse>> getGainedCharacters();
 
-    @Operation(summary = "마케팅 수신 여부 API", description = "마케팅 수신 여부 API")
-    @ApiResponse(responseCode = "200", description = "마케팅 수신 여부 업데이트 성공")
+    @Operation(summary = "마이페이지 API", description = "마이페이지를 조회하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
+    @ApiResponse(responseCode = "200", description = "마이페이지 조회 성공")
+    public ResponseEntity<APISuccessResponse<UserInfoResponse>> getUserInfo();
+
+    @Operation(summary = "회원탈퇴 API", description = "회원탈퇴 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
+    @ApiResponse(responseCode = "204", description = "마이페이지 조회 성공")
+    public ResponseEntity<APISuccessResponse<Void>> softDeleteMember(@RequestBody MemberDeleteRequest request);
+
+    @Operation(summary = "약관 동의 여부 업데이트 API", description = "약관 동의 여부에 따라 업데이트하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
+    @ApiResponse(responseCode = "204", description = "약관 동의 여부 업데이트 성공")
     ResponseEntity<APISuccessResponse<Void>> agreeTerms(
             @RequestBody TermsAgreeRequest termsAgreeRequest
     );

--- a/offroad-api/src/main/java/site/offload/api/member/controller/SocialLoginControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/SocialLoginControllerSwagger.java
@@ -14,8 +14,8 @@ import site.offload.external.oauth.dto.SocialLoginRequest;
 @Tag(name = "Social Login API", description = "소셜 로그인 API")
 public interface SocialLoginControllerSwagger {
 
-    @Operation(summary = "소셜 로그인 API", description = "구글 및 애플 소셜 로그인 구현")
-    @ApiResponse(responseCode = "200", description = "소셜 로그인 성공")
+    @Operation(summary = "로그인 API", description = "구글, 애플, 카카오 소셜 로그인 API입니다.")
+    @ApiResponse(responseCode = "200", description = "로그인 성공")
     ResponseEntity<APISuccessResponse<SocialLoginResponse>> login(
             @RequestBody SocialLoginRequest socialLoginRequest
     );

--- a/offroad-api/src/main/java/site/offload/api/member/controller/TokenControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/member/controller/TokenControllerSwagger.java
@@ -1,6 +1,8 @@
 package site.offload.api.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,6 +16,7 @@ import site.offload.api.response.APISuccessResponse;
 public interface TokenControllerSwagger {
 
     @Operation(summary = "토큰 재발급 API", description = "Refresh Token으로 Access Token, Refresh Token을 재발급하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {refresh_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "201", description = "토큰 재발급 완료")
     ResponseEntity<APISuccessResponse<TokenReissueResponse>> refreshToken(@RequestHeader("Authorization") String tokenHeaderValue);
 }

--- a/offroad-api/src/main/java/site/offload/api/place/controller/PlaceControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/place/controller/PlaceControllerSwagger.java
@@ -1,6 +1,8 @@
 package site.offload.api.place.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -19,12 +21,17 @@ import site.offload.enums.response.SuccessMessage;
 @Tag(name = "Place API", description = "장소 관련 API")
 
 public interface PlaceControllerSwagger {
-    @Operation(summary = "오프로드 등록 장소 조회 API", description = "오프로드 등록 장소 조회 API입니다.")
+    @Operation(summary = "오프로드 등록 장소 조회 API", description = "오프로드에 등록된 장소를 조회하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "오프로드 등록 장소 조회 완료")
-            ResponseEntity<APISuccessResponse<RegisteredPlacesResponse>> getPlaces(
-            @RequestParam double currentLatitude,
-            @RequestParam double currentLongitude,
-            @RequestParam int limit,
-            @RequestParam Boolean isBounded
+    ResponseEntity<APISuccessResponse<RegisteredPlacesResponse>> getPlaces(
+            @Parameter(name = "currentLatitude", description = "현재 위도", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "double"))
+            double currentLatitude,
+            @Parameter(name = "currentLongitude", description = "현재 경도", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "double"))
+            double currentLongitude,
+            @Parameter(name = "limit", description = "제한 거리", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "int"))
+            int limit,
+            @Parameter(name = "isBounded", description = "범위 내 여부", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "Boolean"))
+            Boolean isBounded
     );
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/controller/QuestControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/controller/QuestControllerSwagger.java
@@ -1,6 +1,8 @@
 package site.offload.api.quest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,11 +17,15 @@ import site.offload.api.response.APISuccessResponse;
 @Tag(name = "Quest API", description = "퀘스트 관련 API")
 public interface QuestControllerSwagger {
 
-    @Operation(summary = "퀘스트 정보 조회 API", description = "퀘스트 정보를 조회하는 API입니다.")
+    @Operation(summary = "사용자 퀘스트 정보 조회 API", description = "사용자가 진행중인 퀘스트, 거의 완료한 퀘스트 정보를 조회하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "퀘스트 정보 조회 완료")
     ResponseEntity<APISuccessResponse<QuestResponse>> getQuestInformation();
 
-    @Operation(summary = "퀘스트 목록 조회 API", description = "퀘스트 목록 탭의 정보를 조회하는 API입니다.")
+    @Operation(summary = "전체 퀘스트 목록 조회 API", description = "전체 퀘스트 목록을 조회하는 API입니다.")
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "String"))
     @ApiResponse(responseCode = "200", description = "퀘스트 목록 정보 조회 완료")
-    ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam boolean isActive);
+    ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(
+            @Parameter(name = "isActive", description = "진행 중 여부", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "boolean"))
+            boolean isActive);
 }


### PR DESCRIPTION
## 변경사항

* 소셜 로그인 API를 제외한 모든 API에 대한 swagger를 업데이트 하였습니다.

## Comment

* 소셜 로그인과 관련된 DTO가 현재 external 모듈에 위치되어 있는데, build.gradle에 스웨거 의존성을 추가하는 것은 아닌 것 같아 이를 api 모듈로 옮겼지만 external에서 참조할 수 없는 오류가 발생해 이를 제외하고 업데이트 했습니다.
