### PR TITLE
 [feat] : 공지사항 목록 조회 API 구현

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/announcement/controller/AnnouncementController.java
+++ b/offroad-api/src/main/java/site/offload/api/announcement/controller/AnnouncementController.java
@@ -1,0 +1,26 @@
+package site.offload.api.announcement.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.offload.api.announcement.dto.response.AnnouncementsResponse;
+import site.offload.api.announcement.usecase.AnnouncementUseCase;
+import site.offload.api.response.APISuccessResponse;
+import site.offload.enums.response.SuccessMessage;
+
+@RestController
+@RequestMapping("/api/announcement")
+@RequiredArgsConstructor
+public class AnnouncementController implements AnnouncementControllerSwagger {
+
+    private final AnnouncementUseCase announcementUseCase;
+
+    @GetMapping
+    public ResponseEntity<APISuccessResponse<AnnouncementsResponse>> getAnnouncements() {
+
+        return APISuccessResponse.of(HttpStatus.OK.value(), SuccessMessage.GET_ANNOUNCEMENTS_SUCCESS.getMessage(), announcementUseCase.getAnnouncements());
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/announcement/controller/AnnouncementControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/announcement/controller/AnnouncementControllerSwagger.java
@@ -1,0 +1,28 @@
+package site.offload.api.announcement.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import site.offload.api.announcement.dto.response.AnnouncementsResponse;
+import site.offload.api.response.APISuccessResponse;
+import site.offload.enums.response.SuccessMessage;
+
+@Tag(name = "[Announcement API] 오프로드 공지사항 관련 API")
+public interface AnnouncementControllerSwagger {
+
+    @Operation(summary = "오프로드 공지사항 조회 API", description = "오프로드 공지사항을 불러오는 API입니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "오프로드 공지사항 조회 완료"),
+                    @ApiResponse(responseCode = "400", description = "오프로드 공지사항 조회 실패", content = @Content(schema = @Schema(implementation = SuccessMessage.class)))
+            }
+    )
+    @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "string"))
+    public ResponseEntity<APISuccessResponse<AnnouncementsResponse>> getAnnouncements();
+}

--- a/offroad-api/src/main/java/site/offload/api/announcement/dto/response/AnnouncementDetailResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/announcement/dto/response/AnnouncementDetailResponse.java
@@ -1,0 +1,20 @@
+package site.offload.api.announcement.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementDetailResponse(
+        @Schema(description = "공지사항 제목", example = "제목")
+        String title,
+        @Schema(description = "공지사항 내용", example = "내용")
+        String content,
+        @Schema(description = "중요 공지사항 여부", example = "true")
+        boolean isImportant,
+        @Schema(description = "수정 일자", example = "2024-07-16 21:59:12.000000")
+        LocalDateTime updateAt
+) {
+    public static AnnouncementDetailResponse of(String title, String content, boolean isImportant, LocalDateTime updateAt) {
+        return new AnnouncementDetailResponse(title, content, isImportant, updateAt);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/announcement/dto/response/AnnouncementsResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/announcement/dto/response/AnnouncementsResponse.java
@@ -1,0 +1,14 @@
+package site.offload.api.announcement.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record AnnouncementsResponse(
+        @Schema(description = "공지사항 목록")
+        List<AnnouncementDetailResponse> announcements
+) {
+    public static AnnouncementsResponse of(List<AnnouncementDetailResponse> announcements) {
+        return new AnnouncementsResponse(announcements);
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/announcement/service/AnnouncementService.java
+++ b/offroad-api/src/main/java/site/offload/api/announcement/service/AnnouncementService.java
@@ -1,0 +1,19 @@
+package site.offload.api.announcement.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.offload.db.announcement.entity.AnnouncementEntity;
+import site.offload.db.announcement.repository.AnnouncementRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AnnouncementService {
+
+    private final AnnouncementRepository announcementRepository;
+
+    public List<AnnouncementEntity> getAnnouncements() {
+        return announcementRepository.findAll();
+    }
+}

--- a/offroad-api/src/main/java/site/offload/api/announcement/usecase/AnnouncementUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/announcement/usecase/AnnouncementUseCase.java
@@ -1,0 +1,25 @@
+package site.offload.api.announcement.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.offload.api.announcement.dto.response.AnnouncementDetailResponse;
+import site.offload.api.announcement.dto.response.AnnouncementsResponse;
+import site.offload.api.announcement.service.AnnouncementService;
+import site.offload.db.announcement.entity.AnnouncementEntity;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AnnouncementUseCase {
+
+    private final AnnouncementService announcementService;
+
+    public AnnouncementsResponse getAnnouncements() {
+        List<AnnouncementEntity> announcements = announcementService.getAnnouncements();
+        List<AnnouncementDetailResponse> announcementsDetail = announcements.stream()
+                .map(announcementEntity -> AnnouncementDetailResponse.of(announcementEntity.getTitle(), announcementEntity.getContent(), announcementEntity.isImportant(), announcementEntity.getUpdatedAt()))
+                .toList();
+        return AnnouncementsResponse.of(announcementsDetail);
+    }
+}

--- a/offroad-db/src/main/java/site/offload/db/announcement/entity/AnnouncementEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/announcement/entity/AnnouncementEntity.java
@@ -2,12 +2,14 @@ package site.offload.db.announcement.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.offload.db.BaseTimeEntity;
 
 //공지사항
 @Entity
 @Table(name = "announcement")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnnouncementEntity extends BaseTimeEntity {
 
@@ -23,4 +25,7 @@ public class AnnouncementEntity extends BaseTimeEntity {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
+
+    @Column(nullable = false)
+    private boolean isImportant;
 }

--- a/offroad-db/src/main/java/site/offload/db/announcement/repository/AnnouncementRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/announcement/repository/AnnouncementRepository.java
@@ -1,8 +1,8 @@
 package site.offload.db.announcement.repository;
 
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import site.offload.db.announcement.entity.AnnouncementEntity;
 
-public interface AnnouncementRepository extends CrudRepository<AnnouncementEntity, Long> {
+public interface AnnouncementRepository extends JpaRepository<AnnouncementEntity, Long> {
 }

--- a/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
+++ b/offroad-enum/src/main/java/site/offload/enums/response/SuccessMessage.java
@@ -31,6 +31,7 @@ public enum SuccessMessage {
     GET_MOTIONS_SUCCESS("캐릭터 모션 목록 조회 성공"),
     GET_CHARACTER_DETAIL_SUCCESS("캐릭터 상세 정보 조회 성공"),
     GET_USER_INFO_SUCCESS("사용자 정보 조회 성공"),
-    CHECK_UNVISITED_PLACES_SUCCESS("미방문 장소 목록 조회 성공"),;
+    CHECK_UNVISITED_PLACES_SUCCESS("미방문 장소 목록 조회 성공"),
+    GET_ANNOUNCEMENTS_SUCCESS("오프로드 공지사항 조회 성공");
     private final String message;
 }


### PR DESCRIPTION
## 변경사항

### 공지사항 목록 조회 API 구현
* 공지사항 목록을 불러오는 API를 구현했습다.
* 중요 공지임을 표시하기 위해 AnnounceEntity에 isImortant 필드를 추가했습니다.

## Comment
* 클라이언트분들과 논의가 필요합니다. (ex : 링크가 포함된 공지사항인 경우의 처리)


