### PR TITLE
fix: 신규 획득 여부가 바뀌지 않는 오류 수정

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/charactermotion/usecase/CharacterMotionUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/charactermotion/usecase/CharacterMotionUseCase.java
@@ -28,7 +28,7 @@ public class CharacterMotionUseCase {
     private final MemberService memberService;
     private final S3Service s3Service;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public CharacterMotionsResponse getMotions(Long memberId, Integer characterId) {
         MemberEntity findMemberEntity = memberService.findById(memberId);
         CharacterEntity findCharacterEntity = characterService.findById(characterId);

--- a/offroad-api/src/main/java/site/offload/api/coupon/usecase/CouponListUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/usecase/CouponListUseCase.java
@@ -20,7 +20,7 @@ public class CouponListUseCase {
     private final GainedCouponService gainedCouponService;
 
     //쿠폰 목록은 획득 날짜의 내림차순으로 반환
-    @Transactional(readOnly = true)
+    @Transactional
     public CouponListResponse getCouponList(final long memberId) {
         final List<GainedCouponEntity> findGainedCoupontList = gainedCouponService.findAllByMemberEntityIdOrderByCreatedAtDesc(memberId);
         return CouponListResponse.of(

--- a/offroad-api/src/main/java/site/offload/api/emblem/usecase/EmblemUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/emblem/usecase/EmblemUseCase.java
@@ -58,7 +58,7 @@ public class EmblemUseCase {
                         Emblem.getEmblemByCode(gainedEmblem.getEmblemCode()).getEmblemName())).toList());
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public EmblemsResponse getEmblems(Long memberId) {
         List<QuestRewardEntity> questRewardEntitiesWithEmblems = questRewardService.findQuestWithEmblems();
         List<GainedEmblemEntity> gainedEmblemEntities = gainedEmblemService.findAllByMemberId(memberId);

--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -109,7 +109,7 @@ public class MemberUseCase {
         return ChooseCharacterResponse.of(s3Service.getPresignUrl(findCharacterEntity.getCharacterSpotLightImageUrl()));
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public GainedCharactersResponse getGainedCharacters(Long memberId) {
         List<CharacterEntity> characterEntities = characterService.findAll();
         MemberEntity memberEntity = memberService.findById(memberId);


### PR DESCRIPTION
 ## 변경사항
- 신규 획득 여부를 나타내야 하는 각 도메인의 유스케이스에서 조회 메소드의 트랜잭션 상태가 읽기 전용으로 되어있어서(reaOnly=true 옵션) DB 상태를 업데이트 하는 코드(updateNewGainedStatus())가 작동하지 않아, 이 부분을 제거했습니다.
## 고려사항
- 신규 획득 여부 표시가 필요한 캐릭터, 캐릭터 모션, 쿠폰 목록, 칭호 목록의 조회 메소드를 수정했습니다.
## Comment
- 이에 관한 테스트 코드가 통과한 이유는, 영속성 계층까지는 테스트 범위에 들어가지 않아 통과했던 것 같습니다. 
## Test

## 질문사항

