### PR TITLE
[refactor]: 공지사항 응답 값 수정

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/announcement/dto/response/AnnouncementDetailResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/announcement/dto/response/AnnouncementDetailResponse.java
@@ -3,6 +3,7 @@ package site.offload.api.announcement.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record AnnouncementDetailResponse(
         @Schema(description = "공지사항 제목", example = "제목")
@@ -12,9 +13,13 @@ public record AnnouncementDetailResponse(
         @Schema(description = "중요 공지사항 여부", example = "true")
         boolean isImportant,
         @Schema(description = "수정 일자", example = "2024-07-16 21:59:12.000000")
-        LocalDateTime updateAt
+        LocalDateTime updateAt,
+        @Schema(description = "외부 링크 보유 여부", example = "true")
+        boolean hasExternalLinks,
+        @Schema(description = "외부 링크")
+        List<String> externalLinks
 ) {
-    public static AnnouncementDetailResponse of(String title, String content, boolean isImportant, LocalDateTime updateAt) {
-        return new AnnouncementDetailResponse(title, content, isImportant, updateAt);
+    public static AnnouncementDetailResponse of(String title, String content, boolean isImportant, LocalDateTime updateAt, boolean hasExternalLinks, List<String> externalLinks) {
+        return new AnnouncementDetailResponse(title, content, isImportant, updateAt, hasExternalLinks, externalLinks);
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/announcement/usecase/AnnouncementUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/announcement/usecase/AnnouncementUseCase.java
@@ -18,7 +18,7 @@ public class AnnouncementUseCase {
     public AnnouncementsResponse getAnnouncements() {
         List<AnnouncementEntity> announcements = announcementService.getAnnouncements();
         List<AnnouncementDetailResponse> announcementsDetail = announcements.stream()
-                .map(announcementEntity -> AnnouncementDetailResponse.of(announcementEntity.getTitle(), announcementEntity.getContent(), announcementEntity.isImportant(), announcementEntity.getUpdatedAt()))
+                .map(announcementEntity -> AnnouncementDetailResponse.of(announcementEntity.getTitle(), announcementEntity.getContent(), announcementEntity.isImportant(), announcementEntity.getUpdatedAt(), announcementEntity.isHasExternalLinks(), announcementEntity.getExternalLinks()))
                 .toList();
         return AnnouncementsResponse.of(announcementsDetail);
     }

--- a/offroad-common/src/main/java/site/offload/common/util/StringListConvert.java
+++ b/offroad-common/src/main/java/site/offload/common/util/StringListConvert.java
@@ -1,0 +1,27 @@
+package site.offload.common.util;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Converter
+public class StringListConvert implements AttributeConverter<List<String>, String> {
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        return String.join(",", attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList(dbData.split(","));
+    }
+}

--- a/offroad-db/src/main/java/site/offload/db/announcement/entity/AnnouncementEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/announcement/entity/AnnouncementEntity.java
@@ -4,7 +4,10 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import site.offload.common.util.StringListConvert;
 import site.offload.db.BaseTimeEntity;
+
+import java.util.List;
 
 //공지사항
 @Entity
@@ -28,4 +31,11 @@ public class AnnouncementEntity extends BaseTimeEntity {
 
     @Column(nullable = false)
     private boolean isImportant;
+
+    @Column(nullable = false)
+    private boolean hasExternalLinks;
+
+    @Column(nullable = true)
+    @Convert(converter = StringListConvert.class)
+    private List<String> externalLinks;
 }

--- a/offroad-db/src/main/java/site/offload/db/announcement/entity/AnnouncementEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/announcement/entity/AnnouncementEntity.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import site.offload.common.util.StringListConvert;
+import site.offload.db.util.StringListConvert;
 import site.offload.db.BaseTimeEntity;
 
 import java.util.List;

--- a/offroad-db/src/main/java/site/offload/db/util/StringListConvert.java
+++ b/offroad-db/src/main/java/site/offload/db/util/StringListConvert.java
@@ -1,4 +1,4 @@
-package site.offload.common.util;
+package site.offload.db.util;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;


### PR DESCRIPTION
## 변경사항

### 공지사항 조회 API 반환 값 수정
* 공지사항 조회 API의 반환 값으로 링크 보유 여부, 링크 리스트를 추가 했습니다.
* 이에 따라 공지사항 필드에 해당 값들을 추가했고, 링크 리스트를 DB에 저장하기 위해 문자열 리스트를 DB에 저장할 수 있게 도와주는 util 클래스를 하나 설정했습니다.


