### PR TITLE
fix: 장소에 없는 쿠폰사용코드 체크 수정

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/coupon/usecase/CouponApplyUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/coupon/usecase/CouponApplyUseCase.java
@@ -79,6 +79,11 @@ public class CouponApplyUseCase {
             return false;
         }
 
+        // 쿠폰 코드에 해당하는 장소가 없으면 인증 실패
+        if(!placeService.isExistByCouponAuthCode(request.code())) {
+            return false;
+        }
+
         return true;
     }
 

--- a/offroad-api/src/main/java/site/offload/api/place/service/PlaceService.java
+++ b/offroad-api/src/main/java/site/offload/api/place/service/PlaceService.java
@@ -52,4 +52,8 @@ public class PlaceService {
         );
     }
 
+    public boolean isExistByCouponAuthCode(final String couponAuthCode) {
+        return placeRepository.existsByCouponAuthCode(couponAuthCode);
+    }
+
 }

--- a/offroad-api/src/test/java/site/offload/api/place/service/PlaceEntityServiceTest.java
+++ b/offroad-api/src/test/java/site/offload/api/place/service/PlaceEntityServiceTest.java
@@ -99,4 +99,18 @@ class PlaceEntityServiceTest {
         //then
         Assertions.assertThat(expectedPlaceEntity).isEqualTo(placeEntity);
     }
+
+    @Test
+    @DisplayName("쿠폰 사용 코드에 해당하는 장소가 존재하는지 확인할 수 있다")
+    void checkExistByCouponAuthCode() {
+
+        //given
+        BDDMockito.given(placeRepository.existsByCouponAuthCode(BDDMockito.anyString())).willReturn(true);
+
+        //when
+        boolean expected = placeService.isExistByCouponAuthCode("example");
+
+        //then
+        Assertions.assertThat(expected).isEqualTo(true);
+    }
 }

--- a/offroad-db/src/main/java/site/offload/db/place/repository/PlaceRepository.java
+++ b/offroad-db/src/main/java/site/offload/db/place/repository/PlaceRepository.java
@@ -25,4 +25,6 @@ public interface PlaceRepository extends JpaRepository<PlaceEntity, Long> {
             Pageable pageable
     );
 
+    boolean existsByCouponAuthCode(String couponAuthCode);
+
 }


### PR DESCRIPTION
- close #225 
## 변경사항
- 쿠폰 사용 api에서, 잘못된 쿠폰 사용코드(해당하는 장소가 없을경우)를 요청 시 응답값으로 false가 되도록 수정했습니다.
## 고려사항

## Comment

## Test
- PlaceService에서 쿠폰 코드로 장소값을 찾는 메소드에 대한 테스트 케이스 추가했습니다.
## 질문사항

