### PR TITLE
fix: 반환 캐릭터 이미지 presign url 추가

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/member/usecase/MemberUseCase.java
@@ -152,7 +152,7 @@ public class MemberUseCase {
                 elapsedDays,
                 visitedPlaceService.countByMember(memberEntity),
                 completeQuestService.countByMember(memberEntity),
-                characterEntity.getCharacterBaseImageUrl()
+                s3Service.getPresignUrl(characterEntity.getCharacterBaseImageUrl())
         );
     }
 


### PR DESCRIPTION
## 변경사항
- 기존 반환되던 url이 presign 작업이 되어있지 않아 추가했습니다.
## 고려사항

## Comment
- 회의 내용대로, 디자인분들한테 상반신 이미지 받기전까지 기본이미지로 대체해놓았습니다.
## Test

## 질문사항

