### PR TITLE
feat: 퀘스트 목록 페이지네이션 구현, 리팩토링

### DIFF
--- a/offroad-api/src/main/java/site/offload/api/quest/controller/QuestController.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/controller/QuestController.java
@@ -29,10 +29,12 @@ public class QuestController implements QuestControllerSwagger {
     }
 
     @GetMapping("/quests")
-    public ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam(value = "isActive") boolean isActive) {
+    public ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam(value = "isActive") boolean isActive,
+                                                                                    @RequestParam(value = "cursor") int cursor,
+                                                                                    @RequestParam(value = "size") int size) {
         return APISuccessResponse.of(
                 HttpStatus.OK.value(),
                 SuccessMessage.GET_QUEST_DETAIL_LIST_SUCCESS.getMessage(),
-                questUseCase.getQuestDetailList(PrincipalHandler.getMemberIdFromPrincipal(), isActive));
+                questUseCase.getQuestDetailList(PrincipalHandler.getMemberIdFromPrincipal(), QuestDetailListRequest.of(size, isActive, cursor)));
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/controller/QuestControllerSwagger.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/controller/QuestControllerSwagger.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
-import site.offload.api.quest.dto.request.QuestDetailListRequest;
 import site.offload.api.quest.dto.response.QuestDetailListResponse;
 import site.offload.api.quest.dto.response.QuestResponse;
 import site.offload.api.response.APIErrorResponse;
@@ -38,5 +37,7 @@ public interface QuestControllerSwagger {
             ))
     @Parameter(name = "Authorization", description = "Bearer {access_token}", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "string"))
     @Parameter(name = "isActive", description = "진행중인 퀘스트 요청시 true, 전체 목록 요청시 false", in = ParameterIn.QUERY, required = true, schema = @Schema(type = "boolean"))
-    ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam boolean isActive);
+    ResponseEntity<APISuccessResponse<QuestDetailListResponse>> getQuestList(@RequestParam(value = "isActive") boolean isActive,
+                                                                             @RequestParam(value = "cursor") int cursor,
+                                                                             @RequestParam(value = "size") int size);
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/request/QuestDetailListRequest.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/request/QuestDetailListRequest.java
@@ -3,6 +3,14 @@ package site.offload.api.quest.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record QuestDetailListRequest(
+        @Schema(description = "페이지네이션 사이즈", example = "1")
+        int size,
         @Schema(description = "퀘스트 진행 여부", example = "true")
-        boolean isActive) {
+        boolean isOngoing,
+        @Schema(description = "서버의 마지막 응답 객체 id", example = "1")
+        int cursor) {
+
+        public static QuestDetailListRequest of(int size, boolean isOngoing, int cursor) {
+            return new QuestDetailListRequest(size, isOngoing, cursor);
+        }
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailResponse.java
@@ -16,11 +16,14 @@ public record QuestDetailResponse(
         @Schema(description = "퀘스트 완료 조건", example = "3")
         String requirement,
         @Schema(description = "퀘스트 보상", example = "~쿠폰")
-        String reward) {
+        String reward,
+        @Schema(description = "서버에 api 요청 시 'cursor' 키값에 포함시킬 id", example = "1")
+        int cursorId) {
 
     public static QuestDetailResponse of(String questName, String description,
                                          int currentCount, int totalCount, String requirement,
-                                         String reward) {
+                                         String reward,
+                                         int cursorId) {
         return QuestDetailResponse.builder()
                 .questName(questName)
                 .currentCount(currentCount)
@@ -28,6 +31,11 @@ public record QuestDetailResponse(
                 .requirement(requirement)
                 .reward(reward)
                 .description(description)
+                .cursorId(cursorId)
                 .build();
+    }
+
+    public int getCursorId() {
+        return cursorId;
     }
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailResponse.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/dto/response/QuestDetailResponse.java
@@ -34,8 +34,4 @@ public record QuestDetailResponse(
                 .cursorId(cursorId)
                 .build();
     }
-
-    public int getCursorId() {
-        return cursorId;
-    }
 }

--- a/offroad-api/src/main/java/site/offload/api/quest/usecase/QuestUseCase.java
+++ b/offroad-api/src/main/java/site/offload/api/quest/usecase/QuestUseCase.java
@@ -198,7 +198,7 @@ public class QuestUseCase {
     private List<QuestDetailResponse> getPaginatedListOfQuestDetails(final int size, final List<QuestDetailResponse> questDetails, final int cursor) {
         return questDetails.stream()
                 // 첫 요청시 cursor == 0 (클라와 합의해야되는 내용)
-                .filter(quest -> cursor == 0 || quest.getCursorId() > cursor)
+                .filter(quest -> cursor == 0 || quest.cursorId() > cursor)
                 .limit(size)
                 .toList();
     }

--- a/offroad-api/src/test/java/site/offload/api/quest/usecase/QuestUseCaseTest.java
+++ b/offroad-api/src/test/java/site/offload/api/quest/usecase/QuestUseCaseTest.java
@@ -11,6 +11,7 @@ import site.offload.api.fixture.CompleteQuestEntityFixture;
 import site.offload.api.fixture.MemberEntityFixtureCreator;
 import site.offload.api.fixture.ProceedingQuestEntityFixture;
 import site.offload.api.member.service.MemberService;
+import site.offload.api.quest.dto.request.QuestDetailListRequest;
 import site.offload.api.quest.dto.response.QuestDetailListResponse;
 import site.offload.api.quest.dto.response.QuestDetailResponse;
 import site.offload.api.quest.service.CompleteQuestService;
@@ -28,11 +29,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.anyList;
+import static org.mockito.BDDMockito.given;
 import static site.offload.api.fixture.QuestEntityFixtureCreator.createQuest;
 
 @ExtendWith(MockitoExtension.class)
-public class QuestUseCaseTest {
+class QuestUseCaseTest {
 
     @InjectMocks
     private QuestUseCase questUseCase;
@@ -51,80 +53,170 @@ public class QuestUseCaseTest {
 
     @Test
     @DisplayName("사용자는 진행중인 퀘스트를 달성도 기준 내림차순으로 조회할 수 있다")
-    void getCompletedQuestList() {
+    void getOngoingQuestList() {
 
         //given
-        MemberEntity memberEntity1 = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
+        Long memberId = 1L;
+        MemberEntity memberEntity = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
         QuestEntity questEntity1 = createQuest(true, "test1", PlaceCategory.NONE, PlaceArea.NONE, 100);
         QuestEntity questEntity2 = createQuest(false, "test2", PlaceCategory.CAFFE, PlaceArea.NONE, 50);
         QuestEntity questEntity3 = createQuest(false, "test3", PlaceCategory.CAFFE, PlaceArea.NONE, 10);
 
-        ProceedingQuestEntity proceedingQuestEntity1 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity1);
-        ProceedingQuestEntity proceedingQuestEntity2 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity2);
-        ProceedingQuestEntity proceedingQuestEntity3 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity3);
+        ProceedingQuestEntity proceedingQuestEntity1 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity, questEntity1);
+        ProceedingQuestEntity proceedingQuestEntity2 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity, questEntity2);
+        ProceedingQuestEntity proceedingQuestEntity3 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity, questEntity3);
 
-        given(proceedingQuestService.findAllByMemberId(anyLong())).willReturn(List.of(proceedingQuestEntity1, proceedingQuestEntity2, proceedingQuestEntity3));
+        given(proceedingQuestService.findAllByMemberId(memberId)).willReturn(List.of(proceedingQuestEntity1, proceedingQuestEntity2, proceedingQuestEntity3));
+        QuestDetailListRequest request = QuestDetailListRequest.of(10, true, 0);
 
-        QuestDetailListResponse questDetailList = questUseCase.getQuestDetailList(1L, true);
+        //when
+        QuestDetailListResponse questDetailList = questUseCase.getQuestDetailList(memberId, request);
         List<QuestDetailResponse> actualResponse = questDetailList.questList();
 
-        List<String> expectedQuestNames = new ArrayList<>();
-        for (QuestDetailResponse questDetailResponse : actualResponse) {
-            expectedQuestNames.add(questDetailResponse.questName());
-        }
+        //then
+        List<String> expectedQuestNames = actualResponse.stream()
+                .map(QuestDetailResponse::questName)
+                .toList();
 
         assertThat(expectedQuestNames).containsExactly("test3", "test2", "test1");
     }
 
     @Test
-    @DisplayName("사용자는 진행도 100% 미만 퀘스트를 목록 id오름차순으로 목록 위쪽에, 완료된 퀘스트를 아래쪽에서 조회할 수 있다")
-    void getAllQuest() {
+    @DisplayName("사용자는 완료되지 않은 퀘스트는 ID(pk) 오름차순으로 정렬, 완료된 퀘스트는 그 뒤에 정렬되어(순서상관x) 조회한다.")
+    void getOrderedQuestListSortsQuests() {
         // given
-        MemberEntity memberEntity1 = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
-        QuestEntity questEntity1 = Mockito.spy(createQuest(true, "test1", PlaceCategory.NONE, PlaceArea.NONE, 100));
-        QuestEntity questEntity2 = Mockito.spy(createQuest(false, "test2", PlaceCategory.CAFFE, PlaceArea.NONE, 50));
-        QuestEntity questEntity3 = Mockito.spy(createQuest(false, "test3", PlaceCategory.CAFFE, PlaceArea.NONE, 10));
-        QuestEntity questEntity4 = Mockito.spy(createQuest(false, "test4", PlaceCategory.CAFFE, PlaceArea.NONE, 10));
+        Long memberId = 1L;
+        MemberEntity memberEntity = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
 
-        Mockito.doReturn(4).when(questEntity1).getId();
-        Mockito.doReturn(3).when(questEntity2).getId();
-        Mockito.doReturn(2).when(questEntity3).getId();
-        Mockito.doReturn(1).when(questEntity4).getId();
+        QuestEntity incompleteQuest1 = Mockito.spy(createQuest(false, "incomplete1", PlaceCategory.CAFFE, PlaceArea.NONE, 10));
+        QuestEntity incompleteQuest2 = Mockito.spy(createQuest(false, "incomplete2", PlaceCategory.CAFFE, PlaceArea.NONE, 20));
+        QuestEntity completedQuest1 = Mockito.spy(createQuest(true, "completed1", PlaceCategory.NONE, PlaceArea.NONE, 30));
+        QuestEntity completedQuest2 = Mockito.spy(createQuest(true, "completed2", PlaceCategory.NONE, PlaceArea.NONE, 40));
 
-        //questEntity1,2 완료 가정
-        CompleteQuestEntity completeQuestEntity1 = CompleteQuestEntityFixture.createCompleteQuestEntity(memberEntity1, questEntity1);
-        CompleteQuestEntity completeQuestEntity2 = CompleteQuestEntityFixture.createCompleteQuestEntity(memberEntity1, questEntity2);
+        Mockito.doReturn(2).when(incompleteQuest1).getId();
+        Mockito.doReturn(1).when(incompleteQuest2).getId();
+        Mockito.doReturn(4).when(completedQuest1).getId();
+        Mockito.doReturn(3).when(completedQuest2).getId();
 
-        //questEntity3 진행 중, questEntity4는 시작 전 가정(proceedingQuestEntity 없음)
-        ProceedingQuestEntity proceedingQuestEntity3 = ProceedingQuestEntityFixture.createProceedingQuest(memberEntity1, questEntity3);
+        CompleteQuestEntity completeQuestEntity1 = CompleteQuestEntityFixture.createCompleteQuestEntity(memberEntity, completedQuest1);
+        CompleteQuestEntity completeQuestEntity2 = CompleteQuestEntityFixture.createCompleteQuestEntity(memberEntity, completedQuest2);
 
-        given(memberService.findById(anyLong())).willReturn(memberEntity1);
-        given(completeQuestService.findAllByMemberId(anyLong())).willReturn(List.of(completeQuestEntity1, completeQuestEntity2));
-        given(questService.findByIdNotIn(anyList()))
-                .willReturn(List.of(questEntity3, questEntity4));
-
-        given(proceedingQuestService.existsByMemberAndQuest(memberEntity1, questEntity1)).willReturn(false);
-        given(proceedingQuestService.existsByMemberAndQuest(memberEntity1, questEntity2)).willReturn(false);
-        given(proceedingQuestService.existsByMemberAndQuest(memberEntity1, questEntity3)).willReturn(true);
-        given(proceedingQuestService.existsByMemberAndQuest(memberEntity1, questEntity4)).willReturn(false);
-
-        given(proceedingQuestService.findByMemberAndQuest(memberEntity1, questEntity3)).willReturn(proceedingQuestEntity3);
+        given(memberService.findById(memberId)).willReturn(memberEntity);
+        given(completeQuestService.findAllByMemberId(memberId)).willReturn(List.of(completeQuestEntity1, completeQuestEntity2));
+        given(questService.findByIdNotIn(anyList())).willReturn(List.of(incompleteQuest1, incompleteQuest2)); // id 2,1 순서로 쿼리
+        QuestDetailListRequest request = QuestDetailListRequest.of(4, false, 0);
 
         // when
-        QuestDetailListResponse result = questUseCase.getQuestDetailList(1L, false);
+        List<QuestDetailResponse> result = questUseCase.getQuestDetailList(memberId, request).questList();
 
         // then
-        // 완료된 퀘스트 test1, test2는 뒤 쪽에 있고 진행 중이거나 시작전인 퀘스트는 id 오름차순으로 앞쪽에 정렬
-        assertThat(result.questList())
+        assertThat(result)
                 .hasSize(4)
                 .extracting(QuestDetailResponse::questName)
-                .containsExactly("test4", "test3", "test1", "test2");
-
-        //각 퀘스트의 진행도 표시
-        assertThat(result.questList())
-                .extracting(QuestDetailResponse::currentCount)
-                .containsExactly(0, 1, 100, 50);
-
+                .containsExactly("incomplete2", "incomplete1", "completed1", "completed2");
     }
 
+
+    @Test
+    @DisplayName("사용자는 커서 기반 페이지네이션을 통해 진행중인 퀘스트 목록을 조회할 수 있다.")
+    void getCursorPaginatedCompleteQuestList() {
+        //given
+        Long memberId = 1L;
+        MemberEntity memberEntity = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
+
+        List<QuestEntity> questEntities = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            questEntities.add(createQuest(false, "test" + i, PlaceCategory.NONE, PlaceArea.NONE, 100));
+        }
+
+        List<ProceedingQuestEntity> proceedingQuestEntities = new ArrayList<>();
+        for (QuestEntity questEntity : questEntities) {
+            proceedingQuestEntities.add(ProceedingQuestEntityFixture.createProceedingQuest(memberEntity, questEntity));
+        }
+
+        given(proceedingQuestService.findAllByMemberId(memberId)).willReturn(proceedingQuestEntities);
+        QuestDetailListRequest request1 = QuestDetailListRequest.of(2, true, 0);
+        QuestDetailListRequest request2 = QuestDetailListRequest.of(2, true, 2);
+        QuestDetailListRequest request3 = QuestDetailListRequest.of(2, true, 4);
+
+        //when - 첫 페이지 (커서 0)
+        QuestDetailListResponse firstPageDetailList = questUseCase.getQuestDetailList(memberId, request1);
+        List<QuestDetailResponse> firstPageResponse = firstPageDetailList.questList();
+
+        //then
+        assertThat(firstPageResponse)
+                .hasSize(2)  // 크기 확인
+                .extracting(QuestDetailResponse::questName)
+                .containsExactly("test1", "test2");  // 첫 요청 검증
+
+        //when - 두 번째 페이지 (커서 2)
+        QuestDetailListResponse secondPageDetailList = questUseCase.getQuestDetailList(memberId, request2);
+        List<QuestDetailResponse> secondPageResponse = secondPageDetailList.questList();
+
+        //then
+        assertThat(secondPageResponse)
+                .hasSize(2)  // 크기 확인
+                .extracting(QuestDetailResponse::questName)
+                .containsExactly("test3", "test4");  // 두 번째 요청 검증
+
+        //when - 마지막 페이지 (커서 4)
+        QuestDetailListResponse lastPageDetailList = questUseCase.getQuestDetailList(memberId, request3);
+        List<QuestDetailResponse> lastPageResponse = lastPageDetailList.questList();
+
+        //then
+        assertThat(lastPageResponse)
+                .hasSize(1)  // 마지막 페이지 크기 확인
+                .extracting(QuestDetailResponse::questName)
+                .containsExactly("test5");  // 세 번째 요청 검증
+    }
+
+    @Test
+    @DisplayName("사용자는 커서기반 페이지네이션을 통해 전체 퀘스트 목록을 조회할 수 있다.")
+    void getCursorPaginatedCompletedQuestList() {
+        //given
+        Long memberId = 1L;
+        MemberEntity memberEntity = MemberEntityFixtureCreator.createMemberEntity("sub", "email", SocialPlatform.GOOGLE, "name");
+
+        List<QuestEntity> questEntities = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            questEntities.add(createQuest(true, "test" + i, PlaceCategory.NONE, PlaceArea.NONE, i)); // 완료된 퀘스트
+        }
+
+        given(completeQuestService.findAllByMemberId(memberId)).willReturn(questEntities.stream()
+                .map(questEntity -> CompleteQuestEntityFixture.createCompleteQuestEntity(memberEntity, questEntity)) // 적절한 Entity로 변환
+                .toList());
+        QuestDetailListRequest request1 = QuestDetailListRequest.of(2, false, 0);
+        QuestDetailListRequest request2 = QuestDetailListRequest.of(2, false, 2);
+        QuestDetailListRequest request3 = QuestDetailListRequest.of(2, false, 4);
+
+        //when - 첫 페이지 (커서 0)
+        QuestDetailListResponse firstPageDetailList = questUseCase.getQuestDetailList(memberId, request1);
+        List<QuestDetailResponse> firstPageResponse = firstPageDetailList.questList();
+
+        //then
+        assertThat(firstPageResponse)
+                .hasSize(2)
+                .extracting(QuestDetailResponse::questName)
+                .containsExactly("test1", "test2");  // 첫 요청 검증
+
+        //when - 두 번째 페이지 (커서 2)
+        QuestDetailListResponse secondPageDetailList = questUseCase.getQuestDetailList(memberId, request2);
+        List<QuestDetailResponse> secondPageResponse = secondPageDetailList.questList();
+
+        //then
+        assertThat(secondPageResponse)
+                .hasSize(2)
+                .extracting(QuestDetailResponse::questName)
+                .containsExactly("test3", "test4");  // 두 번째 요청 검증
+
+        //when - 마지막 페이지 (커서 4)
+        QuestDetailListResponse lastPageDetailList = questUseCase.getQuestDetailList(memberId, request3);
+        List<QuestDetailResponse> lastPageResponse = lastPageDetailList.questList();
+
+        //then
+        assertThat(lastPageResponse)
+                .hasSize(1)
+                .extracting(QuestDetailResponse::questName)
+                .containsExactly("test5");  // 세 번째 요청 검증
+    }
 }

--- a/offroad-db/src/main/java/site/offload/db/quest/entity/ProceedingQuestEntity.java
+++ b/offroad-db/src/main/java/site/offload/db/quest/entity/ProceedingQuestEntity.java
@@ -10,7 +10,7 @@ import site.offload.db.member.entity.MemberEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name="proceeding_quest")
+@Table(name = "proceeding_quest")
 public class ProceedingQuestEntity extends BaseTimeEntity {
 
     private static final int DEFAULT_CLEAR_COUNT = 1;
@@ -45,5 +45,10 @@ public class ProceedingQuestEntity extends BaseTimeEntity {
 
     public void updateCurrentClearCount(int currentClearCount) {
         this.currentClearCount = currentClearCount;
+    }
+
+    public boolean isValid() {
+        return this.currentClearCount > 0 &&
+                this.currentClearCount < this.getQuestEntity().getTotalRequiredClearCount();
     }
 }


### PR DESCRIPTION
## 변경사항
- 퀘스트 목록(전체 목록 and 진행 중) 반환 시 무한스크롤을 고려해 페이지네이션 작업을 진행했습니다.
## 고려사항
- 기존에는 Data Jpa의 Pageable 인터페이스를 구현해서 db에 직접 쿼리해 구현할 생각이었는데, 서비스 로직에 정렬 조건과 필터 등 다양한 변수때문에 쿼리가 너무 복잡해져서 유스케이스에서 직접 코드로 구현했습니다. 
## Comment
- 직접 코드로 구현하기 때문에 이 경우 전체 목록을 무조건 가져와야돼서 성능 상 단점이 있을 수 있으나, 퀘스트 도메인 특성 상 데이터의 수가 방대하지는 않기 때문에 이 부분은 괜찮을 것 같습니다( 혹시 우려되신다면 코멘트 남겨주세용)
- 기존에 제가 작성했던 코드가 다시보니 잘 읽히지 않고 지저분한 것 같아 메소드 레벨에서 조금 리팩토링했습니다.
## Test
- 기존 테스트 코드를  페이지네이션을 추가하여 수정했습니다.
## 질문사항

